### PR TITLE
hardhat-compile-fix

### DIFF
--- a/solidity/scripts/deploy.js
+++ b/solidity/scripts/deploy.js
@@ -3,5 +3,5 @@ const { types } = require("hardhat/config");
 task("deploy-home")
   .addParam("slip44", "The origin chain SLIP44 ID", undefined, types.int)
   .addParam("updater", "The origin chain updater", undefined, types.string)
-  .addParam("current root", "The current root")
+  .addParam("currentRoot", "The current root")
   .setAction(async (args) => {});


### PR DESCRIPTION
- fixed camel casing in deploy.js for hardhat compile
- can now run `npm run compile` in solidity directory