### PR TITLE
feature: adds untested relayer daemon

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1570,6 +1570,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
+name = "relayer"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "color-eyre",
+ "config",
+ "ethers",
+ "futures-util",
+ "log",
+ "optics-base",
+ "optics-core",
+ "serde 1.0.120",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -2,5 +2,6 @@
 
 members = [
     "optics-core",
-    "optics-base"
+    "optics-base",
+    "relayer"
 ]

--- a/rust/optics-base/src/abis/ProcessingReplica.abi.json
+++ b/rust/optics-base/src/abis/ProcessingReplica.abi.json
@@ -138,6 +138,19 @@
   },
   {
     "inputs": [],
+    "name": "can_confirm",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "confirm",
     "outputs": [],
     "stateMutability": "nonpayable",

--- a/rust/optics-base/src/abis/mod.rs
+++ b/rust/optics-base/src/abis/mod.rs
@@ -140,6 +140,10 @@ where
         }
     }
 
+    async fn can_confirm(&self) -> Result<bool, ChainCommunicationError> {
+        Ok(self.contract.can_confirm().call().await?)
+    }
+
     async fn confirm(&self) -> Result<TxOutcome, ChainCommunicationError> {
         Ok(self.contract.confirm().send().await?.await?.into())
     }

--- a/rust/optics-core/src/traits/replica.rs
+++ b/rust/optics-core/src/traits/replica.rs
@@ -15,6 +15,9 @@ pub trait Replica: Common + Send + Sync + std::fmt::Debug {
     /// Return the pending root and time, if any
     async fn next_pending(&self) -> Result<Option<(H256, U256)>, ChainCommunicationError>;
 
+    /// Check if there exists a pending update that can be confirmed
+    async fn can_confirm(&self) -> Result<bool, ChainCommunicationError>;
+
     /// Confirm the next pending root (after its timer has elapsed);
     async fn confirm(&self) -> Result<TxOutcome, ChainCommunicationError>;
 

--- a/rust/relayer/Cargo.toml
+++ b/rust/relayer/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "relayer"
+version = "0.1.0"
+authors = ["ltchang <ltchang@stanford.edu>"]
+edition = "2018"
+
+[dependencies]
+tokio = { version = "1.0.1", features = ["rt", "macros"] }
+config = "0.10"
+serde = "1.0.120"
+serde_json = { version = "1.0.61", default-features = false }
+log = "0.4.13"
+ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen"] }
+thiserror = { version = "1.0.22", default-features = false }
+async-trait = { version = "0.1.42", default-features = false }
+futures-util = "0.3.12"
+color-eyre = "0.5.0"
+
+optics-core = { path = "../optics-core" }
+optics-base = { path = "../optics-base" }

--- a/rust/relayer/src/main.rs
+++ b/rust/relayer/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/rust/relayer/src/relayer.rs
+++ b/rust/relayer/src/relayer.rs
@@ -1,0 +1,67 @@
+use async_trait::async_trait;
+use color_eyre::{eyre::ensure, Result};
+use ethers::{signers::Signer, types::Address};
+use std::sync::Arc;
+use tokio::time::{interval, Interval};
+
+use optics_base::agent::OpticsAgent;
+use optics_core::{
+    traits::{Home, Replica},
+    SignedUpdate, Update,
+};
+
+/// A relayer agent
+#[derive(Debug)]
+pub struct Relayer {
+    interval_seconds: u64,
+}
+
+impl Relayer {
+    /// Instantiate a new relayer
+    pub fn new(signer: S, interval_seconds: u64) -> Self {
+        Self {
+            interval_seconds,
+        }
+    }
+
+    #[doc(hidden)]
+    fn interval(&self) -> Interval {
+        interval(std::time::Duration::from_secs(self.interval_seconds))
+    }
+}
+
+#[async_trait]
+impl<E> OpticsAgent for Relayer
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    async fn run(
+        &self,
+        home: Arc<Box<dyn Home>>,
+        _replica: Option<Box<dyn Replica>>,
+    ) -> Result<()> {
+        let mut interval = self.interval();
+        loop {
+            // Get replica's current root
+            let old_root = _replica.current_root().await?;
+
+            // Check for first signed update building off of the replica's current root
+            let signed_update_opt = home.signed_update_by_old_root(old_root).await?;
+
+            // If signed update exists, update replica's current root
+            if let Some(signed_update) = signed_update_opt {
+                _replica.update(signed_update).await?;
+            }
+
+            // Check for pending update that can be confirmed
+            let can_confirm = _replica.can_confirm().await?;
+
+            // If valid pending update exists, confirm it
+            if can_confirm {
+                _replica.confirm().await?;
+            }
+
+            interval.tick().await;
+        }
+    }
+}

--- a/solidity/contracts/Replica.sol
+++ b/solidity/contracts/Replica.sol
@@ -66,6 +66,17 @@ abstract contract Replica is Common, QueueManager {
         queue.enqueue(_newRoot);
     }
 
+    function can_confirm() 
+        external
+        view
+        returns (bool)
+    {
+        if(queue.length() != 0 && block.timestamp >= confirmAt[queue.peek()]) {
+            return true;
+        }
+        return false;
+    }
+
     function confirm() external notFailed {
         require(queue.length() != 0, "No pending");
 


### PR DESCRIPTION
This PR adds a basic `relayer` agent to `optics-base`. Also adds `can_confirm` function to `Replica.sol` so relayer can check that there is confirmable pending update before calling `confirm()`.

Related to #8 