### PR TITLE
docs: download jq for updating abis

### DIFF
--- a/solidity/README.md
+++ b/solidity/README.md
@@ -5,6 +5,7 @@ On-chain implementations of Optics in Solidity.
 ### Setup
 
 - `npm install --dev`
+- `brew install jq` &nbsp; OR &nbsp; `sudo apt-get install jq`
 
 ### Build
 


### PR DESCRIPTION
Adds instructions to download `jq` in solidity docs setup section.

Related to #22 