### PR TITLE
fix: fixes bug where successful updates never set current to newRoot

### DIFF
--- a/solidity/contracts/Home.sol
+++ b/solidity/contracts/Home.sol
@@ -71,6 +71,8 @@ contract Home is MerkleTreeManager, QueueManager, Common {
             bytes32 next = queue.dequeue();
             if (next == _newRoot) break;
         }
+
+        current = _newRoot;
         emit Update(originSLIP44, _oldRoot, _newRoot, _signature);
     }
 

--- a/solidity/test/Home.test.js
+++ b/solidity/test/Home.test.js
@@ -67,6 +67,8 @@ describe('Home', async () => {
     await expect(home.update(currentRoot, newRoot, signature))
       .to.emit(home, 'Update')
       .withArgs(originSLIP44, currentRoot, newRoot, signature);
+
+    expect(await home.current()).to.equal(newRoot);
   });
 
   it('Rejects update that does not build off of current root', async () => {


### PR DESCRIPTION
We forgot to update `current` on successful updates to `Home`. Adds missed line and updates test to expect newly updated `current` field.