### PR TITLE
refactor: changes message handlers to use an interface

### DIFF
--- a/solidity/contracts/test/MockRecipient.sol
+++ b/solidity/contracts/test/MockRecipient.sol
@@ -1,8 +1,18 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.11;
 
-contract MockRecipient {
+import {OpticsHandlerI} from "../Replica.sol";
+
+contract MockRecipient is OpticsHandlerI {
     constructor() {}
+
+    function handle(
+        uint32,
+        bytes32,
+        bytes memory
+    ) external override returns (bytes memory) {
+        return bytes(message());
+    }
 
     function message() public pure returns (string memory) {
         return "message received";

--- a/solidity/lib/Home.abi.json
+++ b/solidity/lib/Home.abi.json
@@ -267,6 +267,19 @@
   },
   {
     "inputs": [],
+    "name": "queueLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "root",
     "outputs": [
       {

--- a/solidity/lib/ProcessingReplica.abi.json
+++ b/solidity/lib/ProcessingReplica.abi.json
@@ -138,6 +138,19 @@
   },
   {
     "inputs": [],
+    "name": "canConfirm",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "confirm",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -237,7 +250,7 @@
   },
   {
     "inputs": [],
-    "name": "next_pending",
+    "name": "nextPending",
     "outputs": [
       {
         "internalType": "bytes32",
@@ -408,6 +421,19 @@
         "internalType": "bytes32",
         "name": "",
         "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "queueLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -2666,9 +2666,9 @@
       }
     },
     "emoji-regex": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.0.tgz",
-      "integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.1.tgz",
+      "integrity": "sha512-117l1H6U4X3Krn+MrzYrL57d5H7siRHWraBs7s+LjRuFK7Fe7hJqnJ0skWlinqsycVLU5YAo6L8CsEYQ0V5prg==",
       "dev": true
     },
     "encodeurl": {
@@ -15000,17 +15000,17 @@
       "dev": true
     },
     "prettier-plugin-solidity": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.3.tgz",
-      "integrity": "sha512-iLbf5ZqwSUqi/BQuRGh+fHy0y3VLX9WayI7qB3wqakSUHItbiKsUKyXbTeho4pfTJVr0D3M4c8BNuEr2OMAOVg==",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.4.tgz",
+      "integrity": "sha512-ceN789x9YB1ysB7R0Dgv4YXotr7ZAlm8FXoCif/xNteuFt/HSrIVOABfzxnmyColUZK+2xUY7WoT2bLld2g/cg==",
       "dev": true,
       "requires": {
         "@solidity-parser/parser": "^0.11.0",
         "dir-to-object": "^2.0.0",
-        "emoji-regex": "^9.0.0",
+        "emoji-regex": "^9.2.1",
         "escape-string-regexp": "^4.0.0",
-        "prettier": "^2.0.5",
-        "semver": "^7.3.2",
+        "prettier": "^2.2.1",
+        "semver": "^7.3.4",
         "solidity-comments-extractor": "^0.0.4",
         "string-width": "^4.2.0"
       }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -10,8 +10,8 @@
     "ethers": "^5.0.29",
     "hardhat": "^2.0.8",
     "hardhat-gas-reporter": "^1.0.4",
-    "prettier": "2.2.1",
-    "prettier-plugin-solidity": "^1.0.0-beta.3",
+    "prettier": "^2.2.1",
+    "prettier-plugin-solidity": "^1.0.0-beta.4",
     "solidity-coverage": "^0.7.14"
   },
   "version": "0.0.0",
@@ -21,7 +21,7 @@
     "test": "test"
   },
   "scripts": {
-    "prettier": "prettier --write 'contracts/**/*.sol' ./test ./scripts",
+    "prettier": "prettier --write './contracts' ./test ./scripts",
     "compile": "hardhat compile && ./scripts/update_abis.sh",
     "coverage": "hardhat coverage",
     "test": "hardhat test"

--- a/solidity/test/Replica.test.js
+++ b/solidity/test/Replica.test.js
@@ -186,13 +186,12 @@ describe('Replica', async () => {
       recipient,
       MockRecipient.abi,
     );
-    await mockRecipient.mock.message.returns(mockRecipientMessageString);
+
+    const mockVal = '0x1234abcd';
+
+    await mockRecipient.mock.handle.returns(mockVal);
 
     const sequence = (await replica.lastProcessed()).add(1);
-
-    // Get selector for mock's message() function
-    const interface = new ethers.utils.Interface(MockRecipient.abi);
-    const selector = interface.getSighash('message()');
 
     const formattedMessage = optics.formatMessage(
       originSLIP44,
@@ -200,7 +199,7 @@ describe('Replica', async () => {
       sequence,
       ownSLIP44,
       mockRecipient.address,
-      selector,
+      '0x',
     );
 
     // Set message status to Message.Pending
@@ -208,9 +207,8 @@ describe('Replica', async () => {
 
     // Static call doesn't change state, only tests return value of external call
     let [success, ret] = await replica.callStatic.process(formattedMessage);
-    [ret] = ethers.utils.defaultAbiCoder.decode(['string'], ret);
     expect(success).to.be.true;
-    expect(ret).to.equal(mockRecipientMessageString);
+    expect(ret).to.equal(mockVal);
 
     // Now test call with state changes
     await replica.process(formattedMessage);


### PR DESCRIPTION
This refactor changes the process message flow to call a specific interface on the recipient, and include the message origin and sender. This allows handlers to handle messages in specific ways based on where the message is from