### PR TITLE
Fix precommit

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -66,7 +66,4 @@ echo >&2 '
 ************
 '
 
-STASHES=$(git stash list)
-if [[ $STASHES == "$STASH_NAME" ]]; then
-  git stash pop -q
-fi
+git stash apply stash^{/$STASH_NAME}


### PR DESCRIPTION
closes #210 

pre-commit script only runs on staged code.  Accomplishes this by stashing unstaged changes, running script and then applying stashed changes