### PR TITLE
refactor: move DB to agentcore

### DIFF
--- a/rust/optics-base/src/db/mod.rs
+++ b/rust/optics-base/src/db/mod.rs
@@ -1,12 +1,21 @@
+use color_eyre::eyre::{Result, WrapErr};
+use rocksdb::{Options, DB};
+use std::path::Path;
+
 /// Shared functionality surrounding use of rocksdb
 pub mod persistence;
+
 pub use persistence::UsingPersistence;
 
-use rocksdb::{Options, DB};
-
 /// Opens db at `db_path` and creates if missing
-pub fn from_path(db_path: String) -> DB {
+pub fn from_path(db_path: &str) -> Result<DB> {
+    let path = Path::new(db_path).canonicalize()?;
+
     let mut opts = Options::default();
     opts.create_if_missing(true);
-    DB::open(&opts, db_path).expect("Failed to open db path")
+
+    Ok(DB::open(&opts, &path).wrap_err(format!(
+        "Failed to open db path {}, canonicalized as {:?}",
+        db_path, path
+    ))?)
 }

--- a/rust/optics-base/src/settings/mod.rs
+++ b/rust/optics-base/src/settings/mod.rs
@@ -3,7 +3,7 @@ use config::{Config, ConfigError, Environment, File};
 use serde::Deserialize;
 use std::{collections::HashMap, env, sync::Arc};
 
-use crate::{home::Homes, replica::Replicas};
+use crate::{db, home::Homes, replica::Replicas};
 
 /// Ethereum configuration
 pub mod ethereum;
@@ -86,6 +86,8 @@ impl ChainSetup {
 /// ```
 #[derive(Debug, Deserialize)]
 pub struct Settings {
+    /// The path to use for the DB file
+    pub db_path: String,
     /// The home configuration
     pub home: ChainSetup,
     /// The replica configurations
@@ -113,7 +115,9 @@ impl Settings {
     pub async fn try_into_core(&self) -> Result<AgentCore, Report> {
         let home = Arc::new(self.try_home().await?);
         let replicas = self.try_replicas().await?;
-        Ok(AgentCore { home, replicas })
+        let db = Arc::new(db::from_path(&self.db_path)?);
+
+        Ok(AgentCore { home, replicas, db })
     }
 
     /// Read settings from the config file


### PR DESCRIPTION
- add db_path to settings for all agents
- refactor updater poll_and_handle_update to use a mutex guard
- add db() method to optics agent trait