### PR TITLE
refactor: initialize updater

### DIFF
--- a/abis/Home.abi.json
+++ b/abis/Home.abi.json
@@ -229,6 +229,13 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",

--- a/abis/Replica.abi.json
+++ b/abis/Replica.abi.json
@@ -183,14 +183,22 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_updaterManager",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint32",
         "name": "_ownDomain",
         "type": "uint32"
-      },
-      {
-        "internalType": "address",
-        "name": "_updater",
-        "type": "address"
       },
       {
         "internalType": "bytes32",
@@ -206,19 +214,6 @@
         "internalType": "uint256",
         "name": "_lastProcessed",
         "type": "uint256"
-      }
-    ],
-    "name": "initialize",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_updater",
-        "type": "address"
       }
     ],
     "name": "initialize",
@@ -488,6 +483,19 @@
   {
     "inputs": [],
     "name": "updater",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "updaterManager",
     "outputs": [
       {
         "internalType": "address",

--- a/solidity/optics-core/contracts/Home.sol
+++ b/solidity/optics-core/contracts/Home.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.6.11;
 import "./Common.sol";
 import "./Merkle.sol";
 import "./Queue.sol";
-import "../interfaces/UpdaterManagerI.sol";
 
 /**
  * @title Home
@@ -18,10 +17,6 @@ contract Home is MerkleTreeManager, QueueManager, Common {
 
     /// @notice Mapping of sequence numbers for each destination
     mapping(uint32 => uint32) public sequences;
-
-    address public updaterManager; // the local entity empowered to manage the updater
-
-    UpdaterManagerI internal updaterManagerI;
 
     /**
      * @notice Event emitted when new message is enqueued
@@ -44,25 +39,11 @@ contract Home is MerkleTreeManager, QueueManager, Common {
     // solhint-disable-next-line no-empty-blocks
     constructor(uint32 _originDomain) payable Common(_originDomain) {}
 
-    function initialize(address _updaterManager) public override {
+    function initialize() public {
         require(state == States.UNINITIALIZED, "already initialized");
-
-        updaterManager = _updaterManager;
-        updaterManagerI = UpdaterManagerI(_updaterManager);
-        updater = UpdaterManagerI(_updaterManager).current();
 
         queue.initialize();
         state = States.ACTIVE;
-    }
-
-    modifier onlyUpdaterManager {
-        require(msg.sender == updaterManager);
-        _;
-    }
-
-    /// @notice Sets updater
-    function setUpdater(address _updater) internal onlyUpdaterManager {
-        updater = _updater;
     }
 
     /// @notice Sets contract state to FAILED and slashes updater

--- a/solidity/optics-core/contracts/Replica.sol
+++ b/solidity/optics-core/contracts/Replica.sol
@@ -49,7 +49,6 @@ abstract contract Replica is Common, QueueManager {
 
     function initialize(
         uint32 _ownDomain,
-        address _updater,
         bytes32 _current,
         uint256 _optimisticSeconds,
         uint256 _lastProcessed
@@ -60,7 +59,6 @@ abstract contract Replica is Common, QueueManager {
 
         ownDomain = _ownDomain;
 
-        updater = _updater;
         current = _current;
         optimisticSeconds = _optimisticSeconds;
         lastProcessed = _lastProcessed;

--- a/solidity/optics-core/test/Home.test.js
+++ b/solidity/optics-core/test/Home.test.js
@@ -34,7 +34,10 @@ describe('Home', async () => {
   });
 
   beforeEach(async () => {
-    const mockSortition = await deployMockContract(signer, TestUpdaterManager.abi);
+    const mockSortition = await deployMockContract(
+      signer,
+      TestUpdaterManager.abi,
+    );
     await mockSortition.mock.current.returns(signer.address);
     await mockSortition.mock.slash.returns();
 


### PR DESCRIPTION
Was confused why we were initializing the updater in 3 different places. Does this seem like a reasonable approach to move this logic from Home to Common?