### PR TITLE
add: codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-*           @prestwich @anna-carroll
-solidity/   @ErinHales
-rust/       @ltchang2019
+*           @prestwich @anna-carroll @erinhales
+rust/       @ltchang2019 @prestwich


### PR DESCRIPTION
Closes #176 

Assigning everyone to review this PR, let me know if you want any adjustments to your ownership.

Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. Code owners are not automatically requested to review draft pull requests.  When you mark a draft pull request as ready for review, code owners are automatically notified. If you convert a pull request to a draft, people who are already subscribed to notifications are not automatically unsubscribed.