### PR TITLE
lint: fix clippy

### DIFF
--- a/rust/optics-ethereum/src/home.rs
+++ b/rust/optics-ethereum/src/home.rs
@@ -101,7 +101,7 @@ where
                     new_root: event.new_root.into(),
                 };
 
-                SignedUpdate { signature, update }
+                SignedUpdate { update, signature }
             })
             .map(Ok)
             .transpose()
@@ -128,7 +128,7 @@ where
                     new_root: event.new_root.into(),
                 };
 
-                SignedUpdate { signature, update }
+                SignedUpdate { update, signature }
             })
             .map(Ok)
             .transpose()

--- a/rust/optics-ethereum/src/replica.rs
+++ b/rust/optics-ethereum/src/replica.rs
@@ -107,7 +107,7 @@ where
                     new_root: event.new_root.into(),
                 };
 
-                SignedUpdate { signature, update }
+                SignedUpdate { update, signature }
             })
             .map(Ok)
             .transpose()
@@ -134,7 +134,7 @@ where
                     new_root: event.new_root.into(),
                 };
 
-                SignedUpdate { signature, update }
+                SignedUpdate { update, signature }
             })
             .map(Ok)
             .transpose()


### PR DESCRIPTION
fixes current lint issues in CI by re-ordering params in struct constructor