### PR TITLE
fix: handles undefined GITHUB_TOKEN

### DIFF
--- a/.github/workflows/mergify.yml
+++ b/.github/workflows/mergify.yml
@@ -28,6 +28,7 @@ jobs:
 
     steps:
       - name: automerge
+        if: ${{ secrets.ACTIONS_PAT }}
         uses: pascalgn/automerge-action@v0.13.1
         env:
           GITHUB_TOKEN: "${{ secrets.ACTIONS_PAT }}"


### PR DESCRIPTION
Only contributors have access to repository secrets.  There isn't a great work around to this so I've disabled the workflow fun if GITHUB_TOKEN is not defined