### PR TITLE
refactor: clean up around ts tests

### DIFF
--- a/typescript/optics-deploy/src/chain.ts
+++ b/typescript/optics-deploy/src/chain.ts
@@ -3,7 +3,8 @@ import { BigNumber } from 'ethers';
 import { BeaconProxy, ProxyAddresses } from './proxyUtils';
 import * as contracts from '../../typechain/optics-core';
 import { NonceManager } from '@ethersproject/experimental';
-import { Address } from '../../optics-tests/lib/types';
+
+type Address = string;
 
 // Optic's complete contract suite
 export type Contracts = {
@@ -69,7 +70,6 @@ export interface ChainConfig {
 // deserialized version of the ChainConfig
 export type Chain = {
   name: string;
-  config: ChainConfig;
   provider: ethers.providers.Provider;
   deployer: ethers.Signer;
   domain: number;
@@ -78,12 +78,14 @@ export type Chain = {
   watchers: Address[];
   gasPrice: ethers.BigNumber;
   confirmations: number;
+  config?: ChainConfig;
 };
 
 // data about a chain and its deployed contracts
 export type Deploy = {
   chain: Chain;
   contracts: Contracts;
+  test?: boolean;
 };
 
 /**
@@ -107,28 +109,6 @@ export function toChain(config: ChainConfig): Chain {
     gasPrice: BigNumber.from(config.gasPrice ?? '20000000000'),
     confirmations: config.confirmations ?? 5,
   };
-}
-
-export function toTestChain(config: ChainConfig, provider: ethers.providers.Provider, signer: ethers.Signer): Chain {
-  return {
-    name: config.name,
-    config: config,
-    provider: provider,
-    deployer: new NonceManager(signer),
-    domain: config.domain,
-    updater: config.updater,
-    optimisticSeconds: config.optimisticSeconds,
-    watchers: config.watchers ?? [],
-    gasPrice: BigNumber.from(config.gasPrice ?? '20000000000'),
-    confirmations: config.confirmations ?? 5,
-  };
-}
-
-export function freshTestDeploy(config: ChainConfig, provider: ethers.providers.Provider, signer: ethers.Signer): Deploy {
-  return {
-    chain: toTestChain(config, provider, signer),
-    contracts: { replicas: {} },
-  }
 }
 
 /**
@@ -180,7 +160,7 @@ export function buildConfig(local: Deploy, remotes: Deploy[]): RustConfig {
     rpcStyle: 'ethereum', // TODO
     connection: {
       type: 'http', // TODO
-      url: local.chain.config.rpc,
+      url: local.chain.config!.rpc,
     },
   };
 
@@ -205,7 +185,7 @@ export function buildConfig(local: Deploy, remotes: Deploy[]): RustConfig {
       rpcStyle: 'ethereum',
       connection: {
         type: 'http',
-        url: remote.chain.config.rpc,
+        url: remote.chain.config!.rpc,
       },
     };
 

--- a/typescript/optics-deploy/src/deployOptics.ts
+++ b/typescript/optics-deploy/src/deployOptics.ts
@@ -21,7 +21,7 @@ import {
  * @param deploy - The deploy instance
  */
 async function deployHome(deploy: Deploy) {
-  await devDeployHome(deploy, false);
+  await devDeployHome(deploy);
 }
 
 /**
@@ -31,7 +31,7 @@ async function deployHome(deploy: Deploy) {
  * @param deploy - The deploy instance
  */
 async function deployGovernanceRouter(deploy: Deploy) {
-  await devDeployGovernanceRouter(deploy, false);
+  await devDeployGovernanceRouter(deploy);
 }
 
 /**
@@ -42,7 +42,7 @@ async function deployGovernanceRouter(deploy: Deploy) {
  * @param remote - The remote deploy instance
  */
 async function deployNewReplica(local: Deploy, remote: Deploy) {
-  await devDeployNewReplica(local, remote, false);
+  await devDeployNewReplica(local, remote);
 }
 
 /**
@@ -52,7 +52,7 @@ async function deployNewReplica(local: Deploy, remote: Deploy) {
  * @param remote - The remote deploy instance
  */
 async function enrollRemote(local: Deploy, remote: Deploy) {
-  await devEnrollRemote(local, remote, false);
+  await devEnrollRemote(local, remote);
 }
 
 /**
@@ -62,7 +62,7 @@ async function enrollRemote(local: Deploy, remote: Deploy) {
  * @param deploy - The deploy instance
  */
 async function deployOptics(deploy: Deploy) {
-  await devDeployOptics(deploy, false);
+  await devDeployOptics(deploy);
 }
 
 /**
@@ -77,7 +77,7 @@ async function deployOptics(deploy: Deploy) {
  * @param chains - An array of chain deploys
  */
 async function deployNChains(chains: Deploy[]) {
-  await devDeployNChains(chains, false);
+  await devDeployNChains(chains);
 }
 
 export {

--- a/typescript/optics-tests/package-lock.json
+++ b/typescript/optics-tests/package-lock.json
@@ -16104,7 +16104,9 @@
           "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-2.0.0.tgz",
           "integrity": "sha512-0xdCkyGOzdqh4h5JSf+zoWx85IusEjDcPIwNEHP8mrWSnCae4rvrqB+/gtpdNfX7zjlFlZiMeePn2r63EI3Lrw==",
           "dev": true,
-          "requires": {}
+          "requires": {
+            "ethers": "^5.0.2"
+          }
         },
         "debug": {
           "version": "4.3.1",

--- a/typescript/optics-tests/test/common.test.ts
+++ b/typescript/optics-tests/test/common.test.ts
@@ -1,9 +1,8 @@
-const { waffle, optics } = require('hardhat');
-const { provider } = waffle;
+const { ethers } = require('hardhat');
 const { expect } = require('chai');
-import { ethers } from 'ethers';
 
 import { TestCommon__factory } from '../../typechain/optics-core';
+import { OpticsState, Updater } from '../lib';
 
 const {
   testCases: signedUpdateTestCases,
@@ -11,14 +10,14 @@ const {
 const localDomain = 1000;
 
 describe('Common', async () => {
-  let common: ethers.Contract;
-  let [signer, fakeSigner] = provider.getWallets();
-  let updater = await optics.Updater.fromSigner(signer, localDomain);
-  let fakeUpdater = await optics.Updater.fromSigner(fakeSigner, localDomain);
+  let common: typeof ethers.Contract;
+  let [signer, fakeSigner] = await ethers.getSigners();
+  let updater = await Updater.fromSigner(signer, localDomain);
+  let fakeUpdater = await Updater.fromSigner(fakeSigner, localDomain);
 
   beforeEach(async () => {
     let commonFactory = new TestCommon__factory(signer);
-    common = await commonFactory.deploy(localDomain, updater.signer.address);
+    common = await commonFactory.deploy(localDomain, updater.address);
   });
 
   it('Accepts updater signature', async () => {
@@ -61,7 +60,7 @@ describe('Common', async () => {
       common.doubleUpdate(oldRoot, [newRoot, newRoot2], signature, signature2),
     ).to.emit(common, 'DoubleUpdate');
 
-    expect(await common.state()).to.equal(optics.State.FAILED);
+    expect(await common.state()).to.equal(OpticsState.FAILED);
   });
 
   it('Does not fail contract on invalid double update proof', async () => {
@@ -81,8 +80,8 @@ describe('Common', async () => {
     // State should not be failed because double update proof does not
     // demonstrate fraud
     const state = await common.state();
-    expect(state).not.to.equal(optics.State.FAILED);
-    expect(state).to.equal(optics.State.ACTIVE);
+    expect(state).not.to.equal(OpticsState.FAILED);
+    expect(state).to.equal(OpticsState.ACTIVE);
   });
 
   it('Checks Rust-produced SignedUpdate', async () => {

--- a/typescript/optics-tests/test/merkle.test.ts
+++ b/typescript/optics-tests/test/merkle.test.ts
@@ -1,7 +1,6 @@
-import { ethers } from 'ethers';
+const { ethers } = require('hardhat');
+const { provider } = ethers;
 
-const { waffle, optics } = require('hardhat');
-const { provider } = waffle;
 const { expect } = require('chai');
 const { TestMerkle__factory } = require('../../typechain/optics-core');
 
@@ -12,10 +11,10 @@ describe('Merkle', async () => {
     const { testName, leaves, expectedRoot, proofs } = testCase;
 
     describe(testName, async () => {
-      let merkle: ethers.Contract, root: string;
+      let merkle: typeof ethers.Contract, root: string;
 
       before(async () => {
-        let [signer] = provider.getWallets();
+        let [signer] = await ethers.getSigners();
         const Merkle = new TestMerkle__factory(signer);
 
         merkle = await Merkle.deploy();

--- a/typescript/optics-tests/test/testChain.ts
+++ b/typescript/optics-tests/test/testChain.ts
@@ -1,0 +1,35 @@
+import { Chain, Deploy } from '../../optics-deploy/src/chain';
+import { ethers } from 'hardhat';
+
+const { BigNumber } = ethers;
+
+export async function getTestChain(
+  domain: number,
+  updater: string,
+  watchers: string[],
+): Promise<Chain> {
+  const [, , , , , , , deployer] = await ethers.getSigners();
+  return {
+    name: 'hh',
+    provider: ethers.provider,
+    deployer,
+    domain,
+    updater,
+    optimisticSeconds: 5,
+    watchers,
+    gasPrice: BigNumber.from('20000000000'),
+    confirmations: 0,
+  };
+}
+
+export async function getTestDeploy(
+  domain: number,
+  updater: string,
+  watcher: string[],
+): Promise<Deploy> {
+  return {
+    chain: await getTestChain(domain, updater, watcher),
+    contracts: { replicas: {} },
+    test: true,
+  };
+}


### PR DESCRIPTION
- add testChain.ts with utility functions for making test Chain and Deploy
- refactor the Optics hardhat extension
- improve typing of enums in Optics lib
- remove most references to waffle (prefer ethers)
- remove isTestDeploy from deployment args in favor of a test? on Deploys

