### PR TITLE
feature: time out txns that have been pending confirmation for 10m

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1935,6 +1935,7 @@ dependencies = [
  "optics-core",
  "serde 1.0.125",
  "serde_json",
+ "tokio",
  "tracing",
 ]
 
@@ -2898,9 +2899,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.5.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+checksum = "570c2eb13b3ab38208130eccd41be92520388791207fde783bda7c1e8ace28d4"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2910,6 +2911,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",
+ "winapi",
 ]
 
 [[package]]

--- a/rust/optics-base/src/agent.rs
+++ b/rust/optics-base/src/agent.rs
@@ -56,7 +56,7 @@ pub trait OpticsAgent: Send + Sync + std::fmt::Debug + AsRef<AgentCore> {
     #[allow(clippy::unit_arg)]
     #[tracing::instrument]
     fn run_report_error(&self, replica: &str) -> JoinHandle<Result<()>> {
-        let m = format!("Replica named {} failed", replica);
+        let m = format!("Task for replica named {} failed", replica);
         let handle = self.run(replica);
 
         let fut = async move { handle.await?.wrap_err(m) };

--- a/rust/optics-core/src/traits/mod.rs
+++ b/rust/optics-core/src/traits/mod.rs
@@ -14,6 +14,7 @@ use ethers::{
     providers::{Middleware, ProviderError},
 };
 use std::error::Error as StdError;
+use tokio::time::error::Elapsed;
 
 use crate::{OpticsError, SignedUpdate};
 
@@ -65,6 +66,9 @@ pub enum ChainCommunicationError {
     /// Provider Error
     #[error("{0}")]
     ProviderError(#[from] ProviderError),
+    /// A transaction timed out during submission
+    #[error("Transaction tracking timed out during submission. {0}")]
+    TimeoutError(#[from] Elapsed),
     /// Any other error
     #[error("{0}")]
     CustomError(#[from] Box<dyn StdError + Send + Sync>),

--- a/rust/optics-ethereum/Cargo.toml
+++ b/rust/optics-ethereum/Cargo.toml
@@ -16,3 +16,4 @@ tracing = "0.1.22"
 color-eyre = "0.5.0"
 
 optics-core = { path = "../optics-core" }
+tokio = "1.7.1"

--- a/rust/optics-ethereum/src/macros.rs
+++ b/rust/optics-ethereum/src/macros.rs
@@ -8,8 +8,9 @@ macro_rules! report_tx {
         tracing::trace!("Call nonce {:?}", $tx.tx.nonce);
         let dispatch_fut = $tx.send();
         let dispatched = dispatch_fut.await?;
-        tracing::debug!("dispatched tx with tx_hash {}", *dispatched);
-        let result = dispatched.await?;
+        tracing::debug!("dispatched tx with tx_hash {:?}", *dispatched);
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(600), dispatched).await??;
         tracing::debug!(
             "confirmed transaction with tx_hash {}",
             result.transaction_hash

--- a/rust/relayer/src/relayer.rs
+++ b/rust/relayer/src/relayer.rs
@@ -70,7 +70,8 @@ impl UpdatePoller {
             if lock.is_err() {
                 return Ok(()); // tx in flight. just do nothing
             }
-            self.replica.update(&signed_update).await?;
+            // don't care if it succeeds
+            let _ = self.replica.update(&signed_update).await;
             // lock dropped here
         } else {
             info!(
@@ -200,16 +201,15 @@ impl OpticsAgent for Relayer {
 
             let (res, _, _) = select_all(vec![confirm_task, update_task]).await;
 
-            let res = res?;
-
-            tracing::error!("Relayer error. {:?}", res);
-            res
+            res?
         })
     }
 }
 
 #[cfg(test)]
 mod test {
+    // // TODO: refactor and re-enable
+
     // use ethers::{core::types::H256, prelude::LocalWallet};
     // use std::sync::Arc;
 


### PR DESCRIPTION
Adds a timeout to all ethereum txn dispatches. Stops polling the pending txn after 600 seconds to prevent permanent deadlocks in agents.

Related to #455 