### PR TITLE
Clarify Home#update notice

### DIFF
--- a/solidity/optics-core/contracts/Home.sol
+++ b/solidity/optics-core/contracts/Home.sol
@@ -154,10 +154,11 @@ contract Home is Initializable, MerkleTreeManager, QueueManager, Common {
     }
 
     /**
-     * @notice Called by updater. Updates home's `current` root from `_oldRoot`
+     * @notice Called with updater's signature. Updates home's `current` root from `_oldRoot`
      * to `_newRoot` and emits `Update` event. If fraudulent update
      * detected in `improperUpdate`, updater is slashed and home is
-     * failed.
+     * failed. Invalid signed roots on a Replica can be submitted
+     * by anyone here on Home and will lead to slashing as well.
      * @param _oldRoot Old merkle root (should equal home's current root)
      * @param _newRoot New merkle root
      * @param _signature Updater's signature on `_oldRoot` and `_newRoot`


### PR DESCRIPTION
This is probably pedantic, but IMO the comment was misleading as it seemed to imply that only the updater calls this function. Instead, in the fraud case, anyone can and should submit the invalid root that was signed to cause slashing. Though I can't claim that my proposed changes are much more clear, so feel free to adjust