### PR TITLE
refactor: fewer trait impls in tracing setup

### DIFF
--- a/rust/kathy/src/main.rs
+++ b/rust/kathy/src/main.rs
@@ -16,7 +16,7 @@ use crate::{kathy::Kathy, settings::KathySettings as Settings};
 async fn _main() -> Result<()> {
     color_eyre::install()?;
     let settings = Settings::new()?;
-    settings.base.tracing.try_init_tracing()?;
+    settings.base.tracing.start_tracing()?;
 
     let agent = Kathy::from_settings(settings).await?;
     agent.run_all().await?;

--- a/rust/optics-base/bin/example.rs
+++ b/rust/optics-base/bin/example.rs
@@ -20,7 +20,7 @@ fn setup() -> Result<Settings> {
     color_eyre::install()?;
 
     let settings = Settings::new()?;
-    settings.tracing.try_init_tracing()?;
+    settings.tracing.start_tracing()?;
 
     Ok(settings)
 }

--- a/rust/optics-base/src/settings/trace/mod.rs
+++ b/rust/optics-base/src/settings/trace/mod.rs
@@ -1,5 +1,4 @@
 use color_eyre::Result;
-use std::convert::TryInto;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{filter::LevelFilter, prelude::*};
 
@@ -72,8 +71,8 @@ pub struct TracingConfig {
 }
 
 impl TracingConfig {
-    /// Attempt to instantiate a register a tracing subscriber setup from settings.
-    pub fn try_init_tracing(&self) -> Result<()> {
+    /// Attempt to instantiate and register a tracing subscriber setup from settings.
+    pub fn start_tracing(&self) -> Result<()> {
         let fmt_layer: LogOutputLayer<_> = self.fmt.into();
         let err_layer = tracing_error::ErrorLayer::default();
 
@@ -86,12 +85,12 @@ impl TracingConfig {
             None => match self.zipkin {
                 None => subscriber.try_init()?,
                 Some(ref zipkin) => {
-                    let layer: OpenTelemetryLayer<_, _> = zipkin.try_into()?;
+                    let layer: OpenTelemetryLayer<_, _> = zipkin.try_into_layer()?;
                     subscriber.with(layer).try_init()?
                 }
             },
             Some(ref jaeger) => {
-                let layer: OpenTelemetryLayer<_, _> = jaeger.try_into()?;
+                let layer: OpenTelemetryLayer<_, _> = jaeger.try_into_layer()?;
                 subscriber.with(layer).try_init()?
             }
         }

--- a/rust/processor/src/main.rs
+++ b/rust/processor/src/main.rs
@@ -20,7 +20,7 @@ use optics_base::agent::OpticsAgent;
 async fn _main() -> Result<()> {
     color_eyre::install()?;
     let settings = Settings::new()?;
-    settings.base.tracing.try_init_tracing()?;
+    settings.base.tracing.start_tracing()?;
 
     let agent = Processor::from_settings(settings).await?;
     agent.run_all().await?;

--- a/rust/relayer/src/main.rs
+++ b/rust/relayer/src/main.rs
@@ -22,7 +22,7 @@ use crate::{relayer::Relayer, settings::RelayerSettings as Settings};
 async fn _main() -> Result<()> {
     color_eyre::install()?;
     let settings = Settings::new()?;
-    settings.base.tracing.try_init_tracing()?;
+    settings.base.tracing.start_tracing()?;
 
     let agent = Relayer::from_settings(settings).await?;
     agent.run_all().await?;

--- a/rust/updater/src/main.rs
+++ b/rust/updater/src/main.rs
@@ -19,7 +19,7 @@ use crate::{settings::UpdaterSettings as Settings, updater::Updater};
 async fn _main() -> Result<()> {
     color_eyre::install()?;
     let settings = Settings::new()?;
-    settings.base.tracing.try_init_tracing()?;
+    settings.base.tracing.start_tracing()?;
 
     let agent = Updater::from_settings(settings).await?;
     agent.run_all().await?;

--- a/rust/watcher/src/main.rs
+++ b/rust/watcher/src/main.rs
@@ -21,7 +21,7 @@ use crate::{settings::WatcherSettings as Settings, watcher::Watcher};
 async fn _main() -> Result<()> {
     color_eyre::install()?;
     let settings = Settings::new()?;
-    settings.base.tracing.try_init_tracing()?;
+    settings.base.tracing.start_tracing()?;
 
     let agent = Watcher::from_settings(settings).await?;
     agent.run_all().await?;


### PR DESCRIPTION
mainly just looks nicer to read by avoiding a bunch of std::convert boilerplate.