### PR TITLE
bug: transfer root governorship to configured governor on gov chain

### DIFF
--- a/typescript/optics-deploy/src/bridge/BridgeDeploy.ts
+++ b/typescript/optics-deploy/src/bridge/BridgeDeploy.ts
@@ -1,4 +1,4 @@
-import { Chain, ChainJson, CoreContractDeployOutput, toChain } from '../chain';
+import { Chain, ChainJson, CoreContractAddresses, toChain } from '../chain';
 import { BridgeContracts } from './BridgeContracts';
 import { parseFileFromDeploy } from '../verification/readDeployOutput';
 import { Deploy } from '../deploy';
@@ -10,7 +10,7 @@ export type BridgeConfig = {
 export class BridgeDeploy extends Deploy<BridgeContracts> {
   readonly config: BridgeConfig;
   readonly coreDeployPath: string;
-  readonly coreContractAddresses: CoreContractDeployOutput;
+  readonly coreContractAddresses: CoreContractAddresses;
 
   constructor(
     chain: Chain,

--- a/typescript/optics-deploy/src/chain.ts
+++ b/typescript/optics-deploy/src/chain.ts
@@ -2,16 +2,23 @@ import * as ethers from 'ethers';
 import { BigNumber } from 'ethers';
 import { NonceManager } from '@ethersproject/experimental';
 import { ProxyAddresses } from './proxyUtils';
+import { Address } from '../../optics-tests/lib/types';
 
 export type DeployEnvironment = 'dev' | 'staging' | 'prod';
 
-export type CoreContractDeployOutput = {
-  upgradeBeaconController: string;
-  xAppConnectionManager: string;
-  updaterManager: string;
+export type CoreContractAddresses = {
+  upgradeBeaconController: Address;
+  xAppConnectionManager: Address;
+  updaterManager: Address;
   governance: ProxyAddresses;
   home: ProxyAddresses;
   replicas?: Record<string, ProxyAddresses>;
+};
+
+export type CoreDeployAddresses = CoreContractAddresses & {
+  recoveryManager: Address;
+  updater: Address;
+  governor?: { address: Address; domain: number };
 };
 
 export interface ChainJson {

--- a/typescript/optics-deploy/src/core/CoreContracts.ts
+++ b/typescript/optics-deploy/src/core/CoreContracts.ts
@@ -1,6 +1,7 @@
 import * as contracts from '../../../typechain/optics-core';
 import { BeaconProxy, ProxyAddresses } from '../proxyUtils';
 import { Contracts } from '../contracts';
+import { CoreContractAddresses } from '../chain';
 
 export class CoreContracts extends Contracts {
   upgradeBeaconController?: contracts.UpgradeBeaconController;
@@ -15,18 +16,18 @@ export class CoreContracts extends Contracts {
     this.replicas = {};
   }
 
-  toObject(): Object {
+  toObject(): CoreContractAddresses {
     const replicas: Record<string, ProxyAddresses> = {};
     Object.entries(this.replicas).forEach(([k, v]) => {
       replicas[k] = v.toObject();
     });
 
     return {
-      upgradeBeaconController: this.upgradeBeaconController?.address,
-      xAppConnectionManager: this.xAppConnectionManager?.address,
-      updaterManager: this.updaterManager?.address,
-      governance: this.governance?.toObject(),
-      home: this.home?.toObject(),
+      upgradeBeaconController: this.upgradeBeaconController!.address,
+      xAppConnectionManager: this.xAppConnectionManager!.address,
+      updaterManager: this.updaterManager!.address,
+      governance: this.governance!.toObject(),
+      home: this.home!.toObject(),
       replicas,
     };
   }

--- a/typescript/optics-deploy/src/core/CoreDeploy.ts
+++ b/typescript/optics-deploy/src/core/CoreDeploy.ts
@@ -11,6 +11,10 @@ import { CoreContracts } from './CoreContracts';
 import { Deploy } from '../deploy';
 import { Address } from '../../../optics-tests/lib/types';
 
+type Governor = {
+  domain: number,
+  address: Address
+}
 export type CoreConfig = {
   environment: DeployEnvironment;
   updater: Address;
@@ -18,7 +22,7 @@ export type CoreConfig = {
   recoveryManager: Address;
   optimisticSeconds: number;
   watchers: string[];
-  governor?: Address;
+  governor?: Governor;
 };
 
 export class CoreDeploy extends Deploy<CoreContracts> {
@@ -37,7 +41,7 @@ export class CoreDeploy extends Deploy<CoreContracts> {
     };
     if (this.config.governor) {
       addresses.governor = {
-        address: this.config.governor,
+        address: this.config.governor.address,
         domain: this.chain.domain,
       };
     }
@@ -49,7 +53,7 @@ export class CoreDeploy extends Deploy<CoreContracts> {
   }
 
   async governor(): Promise<Address> {
-    return this.config.governor ?? (await this.deployer.getAddress());
+    return this.config.governor?.address ?? (await this.deployer.getAddress());
   }
 
   static parseCoreConfig(config: ChainJson & CoreConfig): [Chain, CoreConfig] {

--- a/typescript/optics-deploy/src/core/index.ts
+++ b/typescript/optics-deploy/src/core/index.ts
@@ -50,7 +50,7 @@ export async function deployUpgradeBeaconController(deploy: CoreDeploy) {
  *
  * @param deploy - The deploy instance
  */
- export async function deployUpdaterManager(deploy: CoreDeploy) {
+export async function deployUpdaterManager(deploy: CoreDeploy) {
   let factory = new contracts.UpdaterManager__factory(deploy.deployer);
   deploy.contracts.updaterManager = await factory.deploy(
     deploy.config.updater,
@@ -74,7 +74,7 @@ export async function deployUpgradeBeaconController(deploy: CoreDeploy) {
  *
  * @param deploy - The deploy instance
  */
- export async function deployXAppConnectionManager(deploy: CoreDeploy) {
+export async function deployXAppConnectionManager(deploy: CoreDeploy) {
   const isTestDeploy: boolean = deploy.test;
   if (isTestDeploy) warn('deploying test XAppConnectionManager');
 

--- a/typescript/optics-deploy/src/core/index.ts
+++ b/typescript/optics-deploy/src/core/index.ts
@@ -1,6 +1,3 @@
-// TODO: fix ts errors here
-// @ts-nocheck
-
 import * as ethers from 'ethers';
 import fs from 'fs';
 
@@ -15,7 +12,7 @@ function log(isTest: boolean, str: string) {
   }
 }
 
-function warn(text: string, padded: boolean) {
+function warn(text: string, padded: boolean = false) {
   if (padded) {
     const padding = '*'.repeat(text.length + 8);
     console.log(
@@ -53,14 +50,13 @@ export async function deployUpgradeBeaconController(deploy: CoreDeploy) {
  *
  * @param deploy - The deploy instance
  */
-export async function deployUpdaterManager(deploy: CoreDeploy) {
+ export async function deployUpdaterManager(deploy: CoreDeploy) {
   let factory = new contracts.UpdaterManager__factory(deploy.deployer);
-
   deploy.contracts.updaterManager = await factory.deploy(
     deploy.config.updater,
     deploy.overrides,
   );
-  await deploy.contracts.updaterManager!.deployTransaction.wait(
+  await deploy.contracts.updaterManager.deployTransaction.wait(
     deploy.chain.confirmations,
   );
 
@@ -78,47 +74,7 @@ export async function deployUpdaterManager(deploy: CoreDeploy) {
  *
  * @param deploy - The deploy instance
  */
-export async function deployXAppConnectionManager(deploy: CoreDeploy) {
-  let factory = new contracts.XAppConnectionManager__factory(deploy.deployer);
-  deploy.contracts.xAppConnectionManager = await factory.deploy(
-    deploy.overrides,
-  );
-  await deploy.contracts.xAppConnectionManager.deployTransaction.wait(
-    deploy.chain.confirmations,
-  );
-
-  // add contract information to Etherscan verification array
-  deploy.verificationInput.push({
-    name: 'XAppConnectionManager',
-    address: deploy.contracts.xAppConnectionManager!.address,
-    constructorArguments: [],
-  });
-}
-
-/**
- * Deploys the UpdaterManager on the chain of the given deploy and updates
- * the deploy instance with the new contract.
- *
- * @param deploy - The deploy instance
- */
-export async function deployUpdaterManager(deploy: CoreDeploy) {
-  let factory = new contracts.UpdaterManager__factory(deploy.deployer);
-  deploy.contracts.updaterManager = await factory.deploy(
-    deploy.config.updater,
-    deploy.overrides,
-  );
-  await deploy.contracts.updaterManager.deployTransaction.wait(
-    deploy.chain.confirmations,
-  );
-}
-
-/**
- * Deploys the XAppConnectionManager on the chain of the given deploy and updates
- * the deploy instance with the new contract.
- *
- * @param deploy - The deploy instance
- */
-export async function deployXAppConnectionManager(deploy: CoreDeploy) {
+ export async function deployXAppConnectionManager(deploy: CoreDeploy) {
   const isTestDeploy: boolean = deploy.test;
   if (isTestDeploy) warn('deploying test XAppConnectionManager');
 
@@ -133,6 +89,13 @@ export async function deployXAppConnectionManager(deploy: CoreDeploy) {
   await deploy.contracts.xAppConnectionManager.deployTransaction.wait(
     deploy.chain.confirmations,
   );
+
+  // add contract information to Etherscan verification array
+  deploy.verificationInput.push({
+    name: 'XAppConnectionManager',
+    address: deploy.contracts.xAppConnectionManager!.address,
+    constructorArguments: [],
+  });
 }
 
 /**
@@ -280,7 +243,7 @@ export async function deployOptics(deploy: CoreDeploy) {
   await deployXAppConnectionManager(deploy);
 
   log(isTestDeploy, `${deploy.chain.name}: awaiting deploy Home(deploy);`);
-  await deployHome(deploy, isTestDeploy);
+  await deployHome(deploy);
 
   log(
     isTestDeploy,
@@ -304,7 +267,7 @@ export async function deployOptics(deploy: CoreDeploy) {
     isTestDeploy,
     `${deploy.chain.name}: awaiting deploy GovernanceRouter(deploy);`,
   );
-  await deployGovernanceRouter(deploy, isTestDeploy);
+  await deployGovernanceRouter(deploy);
 
   log(isTestDeploy, `${deploy.chain.name}: initial chain deploy completed`);
 }
@@ -469,15 +432,15 @@ export async function appointGovernor(gov: CoreDeploy) {
   let governor = gov.config.governor;
   if (governor) {
     log(
-      isTestDeploy,
+      gov.test,
       `${gov.chain.name}: transferring root governorship to ${governor}`,
     );
     const tx = await gov.contracts.governance!.proxy.transferGovernor(
-      gov.domain,
-      governor,
+      governor.domain,
+      governor.address,
     );
     await tx.wait(gov.chain.confirmations);
-    log(isTestDeploy, `${gov.chain.name}: root governorship transferred`);
+    log(gov.test, `${gov.chain.name}: root governorship transferred`);
   }
 }
 

--- a/typescript/optics-deploy/src/core/index.ts
+++ b/typescript/optics-deploy/src/core/index.ts
@@ -460,12 +460,12 @@ export async function transferGovernorship(gov: CoreDeploy, non: CoreDeploy) {
 }
 
 /**
- * Installs the intended ultimate governor in that domain's Governance Router.
+ * Appints the intended ultimate governor in that domain's Governance Router.
  * If the governor address is not configured, it will remain the deployer
  * address.
  * @param gov - The governor chain deploy instance
  */
-export async function installGovernor(gov: CoreDeploy) {
+export async function appointGovernor(gov: CoreDeploy) {
   let governor = gov.config.governor;
   if (governor) {
     log(

--- a/typescript/optics-tests/package-lock.json
+++ b/typescript/optics-tests/package-lock.json
@@ -375,7 +375,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.0.tgz",
       "integrity": "sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/address": "^5.4.0",
         "@ethersproject/bignumber": "^5.4.0",
@@ -392,7 +391,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
       "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.4.0",
         "@ethersproject/bytes": "^5.4.0",
@@ -407,7 +405,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
       "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.4.0",
         "@ethersproject/bignumber": "^5.4.0",
@@ -420,7 +417,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
       "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.4.0",
         "@ethersproject/bytes": "^5.4.0",
@@ -433,7 +429,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
       "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.4.0"
       }
@@ -442,7 +437,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
       "integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/properties": "^5.4.0"
@@ -452,7 +446,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
       "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0",
@@ -463,7 +456,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
       "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/logger": "^5.4.0"
       }
@@ -472,7 +464,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
       "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.4.0"
       }
@@ -481,7 +472,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.1.tgz",
       "integrity": "sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-provider": "^5.4.0",
@@ -499,7 +489,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
       "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/address": "^5.4.0",
@@ -515,7 +504,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
       "integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/basex": "^5.4.0",
@@ -535,7 +523,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
       "integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/address": "^5.4.0",
@@ -556,7 +543,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
       "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.4.0",
         "js-sha3": "0.5.7"
@@ -565,14 +551,12 @@
     "node_modules/@ethersproject/logger": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
-      "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==",
-      "dev": true
+      "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
     },
     "node_modules/@ethersproject/networks": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
       "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/logger": "^5.4.0"
       }
@@ -581,7 +565,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
       "integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/sha2": "^5.4.0"
@@ -591,7 +574,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
       "integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/logger": "^5.4.0"
       }
@@ -600,7 +582,6 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.3.tgz",
       "integrity": "sha512-VURwkaWPoUj7jq9NheNDT5Iyy64Qcyf6BOFDwVdHsmLmX/5prNjFrgSX3GHPE4z1BRrVerDxe2yayvXKFm/NNg==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
@@ -627,7 +608,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
       "integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0"
@@ -637,7 +617,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
       "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0"
@@ -647,7 +626,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
       "integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0",
@@ -658,7 +636,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
       "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0",
@@ -672,7 +649,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
       "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.4.0",
         "@ethersproject/bytes": "^5.4.0",
@@ -685,7 +661,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
       "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/constants": "^5.4.0",
@@ -696,7 +671,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
       "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/address": "^5.4.0",
         "@ethersproject/bignumber": "^5.4.0",
@@ -713,7 +687,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
       "integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.4.0",
         "@ethersproject/constants": "^5.4.0",
@@ -724,7 +697,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
       "integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
@@ -747,7 +719,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
       "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/base64": "^5.4.0",
         "@ethersproject/bytes": "^5.4.0",
@@ -760,7 +731,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
       "integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/hash": "^5.4.0",
@@ -1188,8 +1158,7 @@
     "node_modules/aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-      "dev": true
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -1414,8 +1383,7 @@
     "node_modules/bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "dev": true
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -1441,8 +1409,7 @@
     "node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "dev": true
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1469,8 +1436,7 @@
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -1975,7 +1941,6 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -2284,7 +2249,6 @@
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.4.tgz",
       "integrity": "sha512-zaTs8yaDjfb0Zyj8tT6a+/hEkC+kWAA350MWRp6yP5W7NdGcURRPMOpOU+6GtkfxV9wyJEShWesqhE/TjdqpMA==",
-      "dev": true,
       "dependencies": {
         "@ethersproject/abi": "5.4.0",
         "@ethersproject/abstract-provider": "5.4.1",
@@ -12712,7 +12676,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -12731,7 +12694,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -12861,8 +12823,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/invert-kv": {
       "version": "1.0.0",
@@ -13133,8 +13094,7 @@
     "node_modules/js-sha3": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-      "dev": true
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
     },
     "node_modules/js-yaml": {
       "version": "3.13.1",
@@ -13598,14 +13558,12 @@
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -14736,8 +14694,7 @@
     "node_modules/scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-      "dev": true
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "node_modules/secp256k1": {
       "version": "4.0.2",
@@ -15635,7 +15592,6 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       }
@@ -16273,7 +16229,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.0.tgz",
       "integrity": "sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==",
-      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.4.0",
         "@ethersproject/bignumber": "^5.4.0",
@@ -16290,7 +16245,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
       "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.4.0",
         "@ethersproject/bytes": "^5.4.0",
@@ -16305,7 +16259,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
       "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.4.0",
         "@ethersproject/bignumber": "^5.4.0",
@@ -16318,7 +16271,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
       "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.4.0",
         "@ethersproject/bytes": "^5.4.0",
@@ -16331,7 +16283,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
       "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.4.0"
       }
@@ -16340,7 +16291,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
       "integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/properties": "^5.4.0"
@@ -16350,7 +16300,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
       "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0",
@@ -16361,7 +16310,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
       "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
-      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.4.0"
       }
@@ -16370,7 +16318,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
       "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.4.0"
       }
@@ -16379,7 +16326,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.1.tgz",
       "integrity": "sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==",
-      "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-provider": "^5.4.0",
@@ -16397,7 +16343,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
       "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/address": "^5.4.0",
@@ -16413,7 +16358,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
       "integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/basex": "^5.4.0",
@@ -16433,7 +16377,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
       "integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/address": "^5.4.0",
@@ -16454,7 +16397,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
       "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.4.0",
         "js-sha3": "0.5.7"
@@ -16463,14 +16405,12 @@
     "@ethersproject/logger": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
-      "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==",
-      "dev": true
+      "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
     },
     "@ethersproject/networks": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
       "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
-      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.4.0"
       }
@@ -16479,7 +16419,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
       "integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/sha2": "^5.4.0"
@@ -16489,7 +16428,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
       "integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
-      "dev": true,
       "requires": {
         "@ethersproject/logger": "^5.4.0"
       }
@@ -16498,7 +16436,6 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.3.tgz",
       "integrity": "sha512-VURwkaWPoUj7jq9NheNDT5Iyy64Qcyf6BOFDwVdHsmLmX/5prNjFrgSX3GHPE4z1BRrVerDxe2yayvXKFm/NNg==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
@@ -16525,7 +16462,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
       "integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0"
@@ -16535,7 +16471,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
       "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0"
@@ -16545,7 +16480,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
       "integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0",
@@ -16556,7 +16490,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
       "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0",
@@ -16570,7 +16503,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
       "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.4.0",
         "@ethersproject/bytes": "^5.4.0",
@@ -16583,7 +16515,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
       "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/constants": "^5.4.0",
@@ -16594,7 +16525,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
       "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/address": "^5.4.0",
         "@ethersproject/bignumber": "^5.4.0",
@@ -16611,7 +16541,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
       "integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
-      "dev": true,
       "requires": {
         "@ethersproject/bignumber": "^5.4.0",
         "@ethersproject/constants": "^5.4.0",
@@ -16622,7 +16551,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
       "integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
-      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
@@ -16645,7 +16573,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
       "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
-      "dev": true,
       "requires": {
         "@ethersproject/base64": "^5.4.0",
         "@ethersproject/bytes": "^5.4.0",
@@ -16658,7 +16585,6 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
       "integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
-      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/hash": "^5.4.0",
@@ -17055,8 +16981,7 @@
     "aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-      "dev": true
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -17250,8 +17175,7 @@
     "bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "dev": true
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -17274,8 +17198,7 @@
     "bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "dev": true
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -17299,8 +17222,7 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -17730,7 +17652,6 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dev": true,
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -18010,7 +17931,6 @@
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.4.tgz",
       "integrity": "sha512-zaTs8yaDjfb0Zyj8tT6a+/hEkC+kWAA350MWRp6yP5W7NdGcURRPMOpOU+6GtkfxV9wyJEShWesqhE/TjdqpMA==",
-      "dev": true,
       "requires": {
         "@ethersproject/abi": "5.4.0",
         "@ethersproject/abstract-provider": "5.4.1",
@@ -27442,7 +27362,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -27458,7 +27377,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -27571,8 +27489,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -27782,8 +27699,7 @@
     "js-sha3": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-      "dev": true
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -28173,14 +28089,12 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -29083,8 +28997,7 @@
     "scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-      "dev": true
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "secp256k1": {
       "version": "4.0.2",
@@ -29839,8 +29752,7 @@
     "ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
     },
     "xhr": {
       "version": "2.6.0",


### PR DESCRIPTION
1. adds a configuration option and method to transfer the root governorship of the governing chain's governance router on deployment
2. improves the deployment contract output to include other relevant addresses