### PR TITLE
bug: metrics no longer panics when attempting to register multiple replicas

### DIFF
--- a/rust/agents/processor/src/processor.rs
+++ b/rust/agents/processor/src/processor.rs
@@ -299,16 +299,11 @@ impl OpticsAgent for Processor {
         tokio::spawn(async move {
             let replica = replica_opt.ok_or_else(|| eyre!("No replica named {}", name))?;
 
-            let next_to_inspect = prometheus::IntGauge::new(
+            let next_to_inspect = metrics.new_replica_int_gauge(
+                &name,
                 "optics_processor_next_to_inspect_idx",
                 "Index of the next message to inspect",
-            )
-            .expect("metric description failed validation");
-
-            metrics
-                .registry
-                .register(Box::new(next_to_inspect.clone()))
-                .expect("must be able to register agent metrics");
+            )?;
 
             Replica {
                 interval,

--- a/rust/agents/updater/src/updater.rs
+++ b/rust/agents/updater/src/updater.rs
@@ -227,15 +227,12 @@ impl AsRef<AgentCore> for Updater {
 impl Updater {
     /// Instantiate a new updater
     pub fn new(signer: Signers, interval_seconds: u64, update_pause: u64, core: AgentCore) -> Self {
-        let signed_attestation_count = IntCounter::new(
-            "optics_updater_signed_attestation_count",
-            "Number of attestations signed",
-        )
-        .expect("metric description failed validation");
-
-        core.metrics
-            .registry
-            .register(Box::new(signed_attestation_count.clone()))
+        let signed_attestation_count = core
+            .metrics
+            .new_int_counter(
+                "optics_updater_signed_attestation_count",
+                "Number of attestations signed",
+            )
             .expect("must be able to register agent metrics");
 
         Self {


### PR DESCRIPTION
privated the metrics registry and added official interface for setting up per-replica metrics 