### PR TITLE
chore: attempt to refactor LogOutputLayer

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.5.1"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#32ad5a6abd38aa86f33b074881a1d15252c5c9de"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#2e195d91e1c376d6b1e16770afda7a3b8bb6d6dc"
 dependencies = [
  "ethers-contract",
  "ethers-core",
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.5.1"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#32ad5a6abd38aa86f33b074881a1d15252c5c9de"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#2e195d91e1c376d6b1e16770afda7a3b8bb6d6dc"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -927,7 +927,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.5.1"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#32ad5a6abd38aa86f33b074881a1d15252c5c9de"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#2e195d91e1c376d6b1e16770afda7a3b8bb6d6dc"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -949,7 +949,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.5.1"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#32ad5a6abd38aa86f33b074881a1d15252c5c9de"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#2e195d91e1c376d6b1e16770afda7a3b8bb6d6dc"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -963,7 +963,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.5.2"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#32ad5a6abd38aa86f33b074881a1d15252c5c9de"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#2e195d91e1c376d6b1e16770afda7a3b8bb6d6dc"
 dependencies = [
  "arrayvec 0.7.1",
  "bytes",
@@ -988,7 +988,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.5.1"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#32ad5a6abd38aa86f33b074881a1d15252c5c9de"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#2e195d91e1c376d6b1e16770afda7a3b8bb6d6dc"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1011,7 +1011,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.5.2"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#32ad5a6abd38aa86f33b074881a1d15252c5c9de"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#2e195d91e1c376d6b1e16770afda7a3b8bb6d6dc"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1044,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.5.1"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#32ad5a6abd38aa86f33b074881a1d15252c5c9de"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#2e195d91e1c376d6b1e16770afda7a3b8bb6d6dc"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -3446,18 +3446,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/agents/kathy/Cargo.toml
+++ b/rust/agents/kathy/Cargo.toml
@@ -17,7 +17,7 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0", default-features = false}
 thiserror = {version = "1.0.22", default-features = false}
 tokio = {version = "1.0.1", features = ["rt", "macros"]}
-tracing = "0.1.22"
+tracing = "0.1"
 tracing-futures = "0.2.4"
 tracing-subscriber = "0.2.15"
 rand = "0.8.3"

--- a/rust/agents/processor/Cargo.toml
+++ b/rust/agents/processor/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = { version = "1.0.22", default-features = false }
 async-trait = { version = "0.1.42", default-features = false }
 futures-util = "0.3.12"
 color-eyre = "0.5.0"
-tracing = "0.1.22"
+tracing = "0.1"
 tracing-futures = "0.2.4"
 tracing-subscriber = "0.2.15"
 rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb" }

--- a/rust/agents/relayer/Cargo.toml
+++ b/rust/agents/relayer/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = { version = "1.0.22", default-features = false }
 async-trait = { version = "0.1.42", default-features = false }
 futures-util = "0.3.12"
 color-eyre = "0.5.0"
-tracing = "0.1.22"
+tracing = "0.1"
 tracing-futures = "0.2.4"
 tracing-subscriber = "0.2.15"
 

--- a/rust/agents/updater/Cargo.toml
+++ b/rust/agents/updater/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = { version = "1.0.22", default-features = false }
 async-trait = { version = "0.1.42", default-features = false }
 futures-util = "0.3.12"
 color-eyre = "0.5.0"
-tracing = "0.1.22"
+tracing = "0.1"
 tracing-futures = "0.2.4"
 tracing-subscriber = "0.2.15"
 rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb" }

--- a/rust/agents/watcher/Cargo.toml
+++ b/rust/agents/watcher/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = { version = "1.0.22", default-features = false }
 async-trait = { version = "0.1.42", default-features = false }
 futures-util = "0.3.12"
 color-eyre = "0.5.0"
-tracing = "0.1.22"
+tracing = "0.1"
 tracing-futures = "0.2.4"
 tracing-subscriber = "0.2.15"
 rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb" }

--- a/rust/chains/optics-ethereum/Cargo.toml
+++ b/rust/chains/optics-ethereum/Cargo.toml
@@ -14,7 +14,7 @@ ethers = {git = "https://github.com/gakonst/ethers-rs", branch = "master", featu
 ethers-signers = {git = "https://github.com/gakonst/ethers-rs", branch = "master", features = ["aws"]}
 ethers-contract = { git = "https://github.com/gakonst/ethers-rs", branch = "master", features=["legacy"] }
 async-trait = { version = "0.1.42", default-features = false }
-tracing = "0.1.22"
+tracing = "0.1"
 color-eyre = "0.5.0"
 
 optics-core = { path = "../../optics-core" }

--- a/rust/optics-base/Cargo.toml
+++ b/rust/optics-base/Cargo.toml
@@ -16,9 +16,9 @@ thiserror = { version = "1.0.22", default-features = false }
 async-trait = { version = "0.1.42", default-features = false }
 futures-util = "0.3.12"
 color-eyre = "0.5.0"
-tracing = "0.1.22"
+tracing = "0.1"
 tracing-futures = "0.2.4"
-tracing-subscriber = "0.2.15"
+tracing-subscriber = "0.2"
 rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb" }
 
 optics-core = { path = "../optics-core" }

--- a/rust/optics-base/src/settings/trace/fmt.rs
+++ b/rust/optics-base/src/settings/trace/fmt.rs
@@ -4,7 +4,7 @@ use tracing::{span, Subscriber};
 use tracing_subscriber::{
     fmt::{
         self,
-        format::{Compact, DefaultFields, Format, Full, Json, JsonFields, Pretty},
+        format::{Compact, DefaultFields, FmtSpan, Format, Full, Json, JsonFields, Pretty},
     },
     registry::LookupSpan,
     Layer,
@@ -64,11 +64,12 @@ impl<S> Default for LogOutputLayer<S> {
 
 impl<S> From<Style> for LogOutputLayer<S> {
     fn from(style: Style) -> Self {
+        let layer = fmt::layer().with_span_events(FmtSpan::CLOSE);
         match style {
-            Style::Full => Self::Full(fmt::layer()),
-            Style::Pretty => Self::Pretty(fmt::layer().pretty()),
-            Style::Compact => Self::Compact(fmt::layer().compact()),
-            Style::Json => Self::Json(fmt::layer().json()),
+            Style::Full => Self::Full(layer),
+            Style::Pretty => Self::Pretty(layer.pretty()),
+            Style::Compact => Self::Compact(layer.compact()),
+            Style::Json => Self::Json(layer.json()),
         }
     }
 }

--- a/rust/optics-base/src/settings/trace/mod.rs
+++ b/rust/optics-base/src/settings/trace/mod.rs
@@ -69,7 +69,7 @@ impl TracingConfig {
     pub fn start_tracing(&self) -> Result<()> {
         let err_layer = tracing_error::ErrorLayer::default();
 
-        let subscriber = tracing_subscriber::fmt::fmt()
+        let subscriber = tracing_subscriber::registry()
             .with(LevelFilter::from(self.level))
             .with(err_layer)
             .with(self.fmt.layer());

--- a/rust/optics-core/Cargo.toml
+++ b/rust/optics-core/Cargo.toml
@@ -16,7 +16,7 @@ lazy_static = "*"
 thiserror = "*"
 async-trait = { version = "0.1.42", default-features = false }
 tokio = { version = "1.0.1", features = ["rt", "macros"] }
-tracing = "0.1.22"
+tracing = "0.1"
 tracing-futures = "0.2.4"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0"}


### PR DESCRIPTION
it's not successful. kinda a crazy error too. i was hoping a sneaky trait object would prevent needing the `LogOutputLayer` _at all_ but `Box<dyn Layer<S>>` wouldn't stand on its own, and i can't figure out why `LogOutputLayer<S>` doesn't stand alone with the `inner` refactored. the trait impl of `Layer` is still valid -- so why does the callsite induce type horror?

```
error[E0599]: the method `try_init` exists for struct `Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>`, but its trait bounds were not satisfied
   --> optics-base/src/settings/trace/mod.rs:79:36
    |
79  |                 None => subscriber.try_init()?,
    |                                    ^^^^^^^^ method cannot be called on `Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>` due to unsatisfied trait bounds
    | 
   ::: /Users/ember/.cargo/registry/src/github.com-1ecc6299db9ec823/tracing-subscriber-0.2.20/src/layer.rs:560:1
    |
560 | pub struct Layered<L, I, S = I> {
    | -------------------------------
    | |
    | doesn't satisfy `_: Into<Dispatch>`
    | doesn't satisfy `_: SubscriberInitExt`
    |
    = note: the following trait bounds were not satisfied:
            `Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>: Into<Dispatch>`
            which is required by `Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>: SubscriberInitExt`
            `&Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>: Into<Dispatch>`
            which is required by `&Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>: SubscriberInitExt`
            `&mut Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>: Into<Dispatch>`
            which is required by `&mut Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>: SubscriberInitExt`

error[E0599]: the method `try_init` exists for struct `Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>`, but its trait bounds were not satisfied
   --> optics-base/src/settings/trace/mod.rs:82:44
    |
82  |                     subscriber.with(layer).try_init()?
    |                                            ^^^^^^^^ method cannot be called on `Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>` due to unsatisfied trait bounds
    | 
   ::: /Users/ember/.cargo/registry/src/github.com-1ecc6299db9ec823/tracing-subscriber-0.2.20/src/layer.rs:560:1
    |
560 | pub struct Layered<L, I, S = I> {
    | -------------------------------
    | |
    | doesn't satisfy `_: Into<Dispatch>`
    | doesn't satisfy `_: SubscriberInitExt`
    |
    = note: the following trait bounds were not satisfied:
            `Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>: Into<Dispatch>`
            which is required by `Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>: SubscriberInitExt`
            `&Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>: Into<Dispatch>`
            which is required by `&Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>: SubscriberInitExt`
            `&mut Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>: Into<Dispatch>`
            which is required by `&mut Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>: SubscriberInitExt`

error[E0599]: the method `try_init` exists for struct `Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>`, but its trait bounds were not satisfied
   --> optics-base/src/settings/trace/mod.rs:87:40
    |
87  |                 subscriber.with(layer).try_init()?
    |                                        ^^^^^^^^ method cannot be called on `Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>` due to unsatisfied trait bounds
    | 
   ::: /Users/ember/.cargo/registry/src/github.com-1ecc6299db9ec823/tracing-subscriber-0.2.20/src/layer.rs:560:1
    |
560 | pub struct Layered<L, I, S = I> {
    | -------------------------------
    | |
    | doesn't satisfy `_: Into<Dispatch>`
    | doesn't satisfy `_: SubscriberInitExt`
    |
    = note: the following trait bounds were not satisfied:
            `Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>: Into<Dispatch>`
            which is required by `Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>: SubscriberInitExt`
            `&Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>: Into<Dispatch>`
            which is required by `&Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>: SubscriberInitExt`
            `&mut Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>: Into<Dispatch>`
            which is required by `&mut Layered<OpenTelemetryLayer<Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, opentelemetry::sdk::trace::Tracer>, Layered<LogOutputLayer<Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>, Layered<ErrorLayer<Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>, Layered<tracing::level_filters::LevelFilter, tracing_subscriber::Registry>>>>: SubscriberInitExt`

error: aborting due to 3 previous errors; 2 warnings emitted
```