### PR TITLE
feature: dedup DB keys

### DIFF
--- a/rust/agents/processor/src/prover_sync.rs
+++ b/rust/agents/processor/src/prover_sync.rs
@@ -14,6 +14,7 @@ use tracing::{debug, error, info, info_span, instrument, instrument::Instrumente
 #[derive(Debug)]
 pub struct ProverSync {
     db: DB,
+    home_name: String,
     prover: Prover,
     incremental: IncrementalMerkle,
 }
@@ -70,7 +71,7 @@ impl ProverSync {
     fn store_proof(&self, leaf_index: u32) -> Result<(), ProverSyncError> {
         match self.prover.prove(leaf_index as usize) {
             Ok(proof) => {
-                self.db.store_proof(leaf_index, &proof)?;
+                self.db.store_proof(&self.home_name, leaf_index, &proof)?;
                 info!(
                     leaf_index,
                     root = ?self.prover.root(),
@@ -89,14 +90,14 @@ impl ProverSync {
     /// Given rocksdb handle `db` containing merkle tree leaves,
     /// instantiates new `ProverSync` and fills prover's merkle tree
     #[instrument(level = "debug", skip(db))]
-    pub fn from_disk(db: DB) -> Self {
+    pub fn from_disk(home_name: &str, db: DB) -> Self {
         // Ingest all leaves in db into prover tree
         let mut prover = Prover::default();
         let mut incremental = IncrementalMerkle::default();
 
-        if let Some(root) = db.retrieve_latest_root().expect("db error") {
+        if let Some(root) = db.retrieve_latest_root(&home_name).expect("db error") {
             for i in 0.. {
-                match db.leaf_by_leaf_index(i) {
+                match db.leaf_by_leaf_index(&home_name, i) {
                     Ok(Some(leaf)) => {
                         debug!(leaf_index = i, "Ingesting leaf from_disk");
                         prover.ingest(leaf).expect("!tree full");
@@ -120,13 +121,14 @@ impl ProverSync {
             prover,
             incremental,
             db,
+            home_name: home_name.to_owned(),
         };
 
         // Ensure proofs exist for all leaves
         for i in 0.. {
             match (
-                sync.db.leaf_by_leaf_index(i).expect("db error"),
-                sync.db.proof_by_leaf_index(i).expect("db error"),
+                sync.db.leaf_by_leaf_index(&home_name, i).expect("db error"),
+                sync.db.proof_by_leaf_index(&home_name, i).expect("db error"),
             ) {
                 (Some(_), None) => sync.store_proof(i).expect("db error"),
                 (None, _) => break,
@@ -153,7 +155,7 @@ impl ProverSync {
         let mut leaves = vec![];
 
         for i in range {
-            let leaf = self.db.wait_for_leaf(i as u32).await?;
+            let leaf = self.db.wait_for_leaf(&self.home_name, i as u32).await?;
             if leaf.is_none() {
                 break;
             }
@@ -213,7 +215,7 @@ impl ProverSync {
         // calculate a proof under the current root for each leaf
         // store all calculated proofs in the db
         for idx in start..end {
-            if self.db.proof_by_leaf_index(idx as u32)?.is_none() {
+            if self.db.proof_by_leaf_index(&self.home_name, idx as u32)?.is_none() {
                 self.store_proof(idx as u32)?;
             }
         }
@@ -260,7 +262,7 @@ impl ProverSync {
             // As we fill the incremental merkle, its tree_size will always be
             // equal to the index of the next leaf we want (e.g. if tree_size
             // is 3, we want the 4th leaf, which is at index 3)
-            if let Some(leaf) = self.db.wait_for_leaf(tree_size as u32).await? {
+            if let Some(leaf) = self.db.wait_for_leaf(&self.home_name, tree_size as u32).await? {
                 info!(
                     index = tree_size,
                     leaf = ?leaf,
@@ -303,7 +305,7 @@ impl ProverSync {
         tokio::spawn(async move {
             loop {
                 let local_root = self.local_root();
-                let signed_update_opt = self.db.update_by_previous_root(local_root)?;
+                let signed_update_opt = self.db.update_by_previous_root(&self.home_name, local_root)?;
 
                 // This if block is somewhat ugly.
                 // First we check if there is a signed update with the local root.
@@ -319,7 +321,7 @@ impl ProverSync {
                     );
                     self.update_full(local_root, signed_update.update.new_root)
                         .await?;
-                } else if !local_root.is_zero() && self.db.update_by_new_root(local_root)?.is_none()
+                } else if !local_root.is_zero() && self.db.update_by_new_root(&self.home_name, local_root)?.is_none()
                 {
                     bail!(ProverSyncError::InvalidLocalRoot { local_root });
                 }

--- a/rust/agents/updater/src/updater.rs
+++ b/rust/agents/updater/src/updater.rs
@@ -74,7 +74,7 @@ impl UpdateHandler {
 
     fn check_conflict(&self, update: &Update) -> Option<SignedUpdate> {
         self.db
-            .update_by_previous_root(update.previous_root)
+            .update_by_previous_root(&self.home.name(), update.previous_root)
             .expect("db failure")
     }
 
@@ -157,7 +157,7 @@ impl UpdateHandler {
         self.home.update(&signed).await?;
 
         info!("Storing signed update in db");
-        self.db.store_update(&signed)?;
+        self.db.store_update(&self.home.name(), &signed)?;
         Ok(())
         // guard dropped here
     }

--- a/rust/optics-core/src/db/mod.rs
+++ b/rust/optics-core/src/db/mod.rs
@@ -15,18 +15,20 @@ use crate::{
 
 use self::iterator::PrefixIterator;
 
-static NONCE: &str = "destination_and_nonce_";
-static LEAF_IDX: &str = "leaf_index_";
-static LEAF_HASH: &str = "leaf_hash_";
-static PREV_ROOT: &str = "update_prev_root_";
-static NEW_ROOT: &str = "update_new_root_";
-static LATEST_ROOT: &str = "update_latest_root_";
-static PROOF: &str = "proof_";
+// Type prefixes
+static NONCE: &str = "_destination_and_nonce_";
+static LEAF_IDX: &str = "_leaf_index_";
+static LEAF_HASH: &str = "_leaf_hash_";
+static PREV_ROOT: &str = "_update_prev_root_";
+static NEW_ROOT: &str = "_update_new_root_";
+static LATEST_ROOT: &str = "_update_latest_root_";
+static PROOF: &str = "_proof_";
+static LATEST_LEAF: &str = "_latest_known_leaf_";
 
-static LATEST_LEAF: &str = "latest_known_leaf_";
-
-#[derive(Debug, Clone)]
 /// A KV Store
+///
+/// Key structure: ```<home_name>_<type_prefix>_<key>```
+#[derive(Debug, Clone)]
 pub struct DB(Arc<Rocks>);
 
 impl From<Rocks> for DB {


### PR DESCRIPTION
- all db methods take home_name as added prefix
- lots of repeated code given that every db method requires a home_name (consider pairing DB with home name?)