### PR TITLE
fix: fix potential out-of-order updates when `HomeIndexer` syncing

### DIFF
--- a/rust/agents/processor/src/prover_sync.rs
+++ b/rust/agents/processor/src/prover_sync.rs
@@ -79,7 +79,8 @@ impl ProverSync {
                 );
                 Ok(())
             }
-            // ignore the storage request if it's out of range
+            // ignore the storage request if it's out of range (e.g. leaves 
+            // up-to-date but no update containing leaves produced yet)
             Err(ProverError::ZeroProof { index: _, count: _ }) => Ok(()),
             // bubble up any other errors
             Err(e) => Err(e.into()),

--- a/rust/agents/processor/src/prover_sync.rs
+++ b/rust/agents/processor/src/prover_sync.rs
@@ -124,7 +124,7 @@ impl ProverSync {
         };
 
         // Ensure proofs exist for all leaves
-        for i in 0..sync.prover.count() as u32 {
+        for i in 0.. {
             match (
                 sync.db.leaf_by_leaf_index(i).expect("db error"),
                 sync.db.proof_by_leaf_index(i).expect("db error"),

--- a/rust/agents/processor/src/prover_sync.rs
+++ b/rust/agents/processor/src/prover_sync.rs
@@ -124,7 +124,7 @@ impl ProverSync {
         };
 
         // Ensure proofs exist for all leaves
-        for i in 0.. {
+        for i in 0..sync.prover.count() as u32 {
             match (
                 sync.db.leaf_by_leaf_index(i).expect("db error"),
                 sync.db.proof_by_leaf_index(i).expect("db error"),

--- a/rust/agents/processor/src/prover_sync.rs
+++ b/rust/agents/processor/src/prover_sync.rs
@@ -79,7 +79,7 @@ impl ProverSync {
                 );
                 Ok(())
             }
-            // ignore the storage request if it's out of range (e.g. leaves 
+            // ignore the storage request if it's out of range (e.g. leaves
             // up-to-date but no update containing leaves produced yet)
             Err(ProverError::ZeroProof { index: _, count: _ }) => Ok(()),
             // bubble up any other errors
@@ -124,7 +124,7 @@ impl ProverSync {
         };
 
         // Ensure proofs exist for all leaves
-        for i in 0.. {
+        for i in 0..sync.prover.count() as u32 {
             match (
                 sync.db.leaf_by_leaf_index(i).expect("db error"),
                 sync.db.proof_by_leaf_index(i).expect("db error"),

--- a/rust/agents/updater/src/updater.rs
+++ b/rust/agents/updater/src/updater.rs
@@ -157,7 +157,7 @@ impl UpdateHandler {
         self.home.update(&signed).await?;
 
         info!("Storing signed update in db");
-        self.home_db.store_update(&signed)?;
+        self.db.store_latest_update(&signed)?;
         Ok(())
         // guard dropped here
     }

--- a/rust/agents/updater/src/updater.rs
+++ b/rust/agents/updater/src/updater.rs
@@ -157,7 +157,7 @@ impl UpdateHandler {
         self.home.update(&signed).await?;
 
         info!("Storing signed update in db");
-        self.db.store_latest_update(&signed)?;
+        self.home_db.store_latest_update(&signed)?;
         Ok(())
         // guard dropped here
     }

--- a/rust/agents/watcher/src/watcher.rs
+++ b/rust/agents/watcher/src/watcher.rs
@@ -187,7 +187,7 @@ impl UpdateHandler {
                 }
             }
             None => {
-                self.db.store_update(update).expect("!db_put");
+                self.db.store_latest_update(update).expect("!db_put");
             }
         }
 

--- a/rust/chains/optics-ethereum/src/home.rs
+++ b/rust/chains/optics-ethereum/src/home.rs
@@ -49,29 +49,38 @@ where
 {
     #[instrument(err, skip(self))]
     async fn sync_updates(&self, from: u32, to: u32) -> Result<()> {
-        let events = self
+        let mut events = self
             .contract
             .update_filter()
             .from_block(from)
             .to_block(to)
-            .query()
+            .query_with_meta()
             .await?;
 
+        events.sort_by(|a, b| {
+            let mut ordering = a.1.block_number.cmp(&b.1.block_number);
+            if ordering == std::cmp::Ordering::Equal {
+                ordering = a.1.transaction_index.cmp(&b.1.transaction_index);
+            }
+
+            ordering
+        });
+
         let updates = events.iter().map(|event| {
-            let signature = Signature::try_from(event.signature.as_slice())
+            let signature = Signature::try_from(event.0.signature.as_slice())
                 .expect("chain accepted invalid signature");
 
             let update = Update {
-                home_domain: event.home_domain,
-                previous_root: event.old_root.into(),
-                new_root: event.new_root.into(),
+                home_domain: event.0.home_domain,
+                previous_root: event.0.old_root.into(),
+                new_root: event.0.new_root.into(),
             };
 
             SignedUpdate { update, signature }
         });
 
         for update in updates {
-            self.home_db.store_update(&update)?;
+            self.db.store_latest_update(&update)?;
         }
 
         Ok(())
@@ -127,7 +136,11 @@ where
                     next_height,
                     to
                 );
-                // TODO(james): these shouldn't have to go in lockstep
+                // WARN: update and leave syncing running concurrently means db
+                // may have snapshots where leaf and update state are
+                // temporarily out of sync!
+                // TODO(luke/james): add extra synchronization to ensure update
+                // and leaf state always read from db when in sync
                 try_join!(
                     self.sync_updates(next_height, to),
                     self.sync_leaves(next_height, to)

--- a/rust/chains/optics-ethereum/src/home.rs
+++ b/rust/chains/optics-ethereum/src/home.rs
@@ -80,7 +80,7 @@ where
         });
 
         for update in updates {
-            self.db.store_latest_update(&update)?;
+            self.home_db.store_latest_update(&update)?;
         }
 
         Ok(())
@@ -137,6 +137,7 @@ where
                     to
                 );
 
+                // TODO(james): these shouldn't have to go in lockstep
                 try_join!(
                     self.sync_updates(next_height, to),
                     self.sync_leaves(next_height, to)

--- a/rust/chains/optics-ethereum/src/home.rs
+++ b/rust/chains/optics-ethereum/src/home.rs
@@ -136,11 +136,7 @@ where
                     next_height,
                     to
                 );
-                // WARN: update and leave syncing running concurrently means db
-                // may have snapshots where leaf and update state are
-                // temporarily out of sync!
-                // TODO(luke/james): add extra synchronization to ensure update
-                // and leaf state always read from db when in sync
+
                 try_join!(
                     self.sync_updates(next_height, to),
                     self.sync_leaves(next_height, to)


### PR DESCRIPTION
- Orders queried update events by `blocknumber` and `transaction_index` within block (should solve skipped messages issue?)
- Stop proversync leaf/proof check at `prover.count()` (don't try to build proofs for leaves without an update yet)
- Adds `warn!` when we attempt to store root that doesn't build off latest root (shouldn't happen anymore though after fix)

Potentially related to #812