### PR TITLE
feature: optionally skip replica tasks

### DIFF
--- a/rust/agents/processor/src/processor.rs
+++ b/rust/agents/processor/src/processor.rs
@@ -249,7 +249,7 @@ decl_agent!(
         allowed: Option<Arc<HashSet<H256>>>,
         denied: Option<Arc<HashSet<H256>>>,
         next_message_index: prometheus::IntGaugeVec,
-        process: bool,
+        index_only: bool,
     }
 );
 
@@ -260,7 +260,7 @@ impl Processor {
         core: AgentCore,
         allowed: Option<HashSet<H256>>,
         denied: Option<HashSet<H256>>,
-        process: bool,
+        index_only: bool,
     ) -> Self {
         let next_message_index = core
             .metrics
@@ -269,7 +269,7 @@ impl Processor {
                 "Index of the next message to inspect",
                 &["replica", "agent"],
             )
-            .expect("Processor metric already registered -- should have be a singleton");
+            .expect("processor metric already registered -- should have be a singleton");
 
         Self {
             interval,
@@ -278,7 +278,7 @@ impl Processor {
             allowed: allowed.map(Arc::new),
             denied: denied.map(Arc::new),
             next_message_index,
-            process,
+            index_only,
         }
     }
 }
@@ -299,7 +299,7 @@ impl OpticsAgent for Processor {
             settings.as_ref().try_into_core(AGENT_NAME).await?,
             settings.allowed,
             settings.denied,
-            settings.index.is_none(),
+            settings.index.is_some(),
         ))
     }
 
@@ -366,10 +366,10 @@ impl OpticsAgent for Processor {
 
             info!("started indexer and sync");
 
-            // instantiate task array here so we can optionally push to to
+            // instantiate task array here so we can optionally push run_task
             let mut tasks = vec![index_task, sync_task];
 
-            if self.process {
+            if !self.index_only {
                 // this is the unused must use
                 let names: Vec<&str> = self.replicas().keys().map(|k| k.as_str()).collect();
                 tasks.push(self.run_many(&names));

--- a/rust/agents/processor/src/processor.rs
+++ b/rust/agents/processor/src/processor.rs
@@ -249,6 +249,7 @@ decl_agent!(
         allowed: Option<Arc<HashSet<H256>>>,
         denied: Option<Arc<HashSet<H256>>>,
         next_message_index: prometheus::IntGaugeVec,
+        process: bool,
     }
 );
 
@@ -259,6 +260,7 @@ impl Processor {
         core: AgentCore,
         allowed: Option<HashSet<H256>>,
         denied: Option<HashSet<H256>>,
+        process: bool,
     ) -> Self {
         let next_message_index = core
             .metrics
@@ -276,6 +278,7 @@ impl Processor {
             allowed: allowed.map(Arc::new),
             denied: denied.map(Arc::new),
             next_message_index,
+            process,
         }
     }
 }
@@ -296,6 +299,7 @@ impl OpticsAgent for Processor {
             settings.as_ref().try_into_core(AGENT_NAME).await?,
             settings.allowed,
             settings.denied,
+            settings.index.is_none(),
         ))
     }
 
@@ -362,15 +366,16 @@ impl OpticsAgent for Processor {
 
             info!("started indexer and sync");
 
-            // this is the unused must use
-            let names: Vec<&str> = self.replicas().keys().map(|k| k.as_str()).collect();
-            let run_task = self.run_many(&names);
+            // instantiate task array here so we can optionally push to to
+            let mut tasks = vec![index_task, sync_task];
 
-            // info!("resting");
-            // sleep(Duration::from_secs(5000)).await;
+            if self.process {
+                // this is the unused must use
+                let names: Vec<&str> = self.replicas().keys().map(|k| k.as_str()).collect();
+                tasks.push(self.run_many(&names));
+            }
 
             info!("selecting");
-            let tasks = vec![index_task, run_task, sync_task];
             let (res, _, remaining) = select_all(tasks).await;
 
             for task in remaining.into_iter() {

--- a/rust/agents/processor/src/settings.rs
+++ b/rust/agents/processor/src/settings.rs
@@ -11,4 +11,6 @@ decl_settings!(Processor {
     allowed: Option<HashSet<H256>>,
     /// A deny list of message senders
     denied: Option<HashSet<H256>>,
+    /// Only index transactions if this key is set
+    index: Option<String>,
 });


### PR DESCRIPTION
Adds a `sync` config param. Setting this param to any string value will put the processor in sync-only mode. The processor will not dispatch txns to replicas, it will only sync the DB.