### PR TITLE
feature: `HomeIndexer` stores update metadata

### DIFF
--- a/rust/chains/optics-ethereum/src/home.rs
+++ b/rust/chains/optics-ethereum/src/home.rs
@@ -5,6 +5,7 @@ use color_eyre::Result;
 use ethers::contract::abigen;
 use ethers::core::types::{Address, Signature, H256};
 use optics_core::db::{HomeDB, DB};
+use optics_core::SignedUpdateWithMeta;
 use optics_core::{
     traits::{
         ChainCommunicationError, Common, DoubleUpdate, Home, RawCommittedMessage, State, TxOutcome,
@@ -66,7 +67,7 @@ where
             ordering
         });
 
-        let updates = events.iter().map(|event| {
+        let updates_with_meta = events.iter().map(|event| {
             let signature = Signature::try_from(event.0.signature.as_slice())
                 .expect("chain accepted invalid signature");
 
@@ -76,11 +77,19 @@ where
                 new_root: event.0.new_root.into(),
             };
 
-            SignedUpdate { update, signature }
+            SignedUpdateWithMeta {
+                signed_update: SignedUpdate { update, signature },
+                block_number: event.1.block_number.as_u64(),
+            }
         });
 
-        for update in updates {
-            self.home_db.store_latest_update(&update)?;
+        for update_with_meta in updates_with_meta {
+            self.home_db
+                .store_latest_update(&update_with_meta.signed_update)?;
+            self.home_db.store_update_block_number(
+                update_with_meta.signed_update.update.new_root,
+                update_with_meta.block_number,
+            )?;
         }
 
         Ok(())

--- a/rust/chains/optics-ethereum/src/home.rs
+++ b/rust/chains/optics-ethereum/src/home.rs
@@ -10,7 +10,7 @@ use optics_core::{
     traits::{
         ChainCommunicationError, Common, DoubleUpdate, Home, RawCommittedMessage, State, TxOutcome,
     },
-    Message, SignedUpdate, Update,
+    Message, SignedUpdate, Update, UpdateMeta,
 };
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
@@ -79,16 +79,18 @@ where
 
             SignedUpdateWithMeta {
                 signed_update: SignedUpdate { update, signature },
-                block_number: event.1.block_number.as_u64(),
+                metadata: UpdateMeta {
+                    block_number: event.1.block_number.as_u64(),
+                },
             }
         });
 
         for update_with_meta in updates_with_meta {
             self.home_db
                 .store_latest_update(&update_with_meta.signed_update)?;
-            self.home_db.store_update_block_number(
+            self.home_db.store_update_metadata(
                 update_with_meta.signed_update.update.new_root,
-                update_with_meta.block_number,
+                update_with_meta.metadata,
             )?;
         }
 

--- a/rust/optics-core/src/db/home_db.rs
+++ b/rust/optics-core/src/db/home_db.rs
@@ -1,4 +1,5 @@
 use crate::db::{DbError, TypedDB, DB};
+use crate::UpdateMeta;
 use crate::{
     accumulator::merkle::Proof, traits::RawCommittedMessage, utils, Decode, Encode, OpticsMessage,
     SignedUpdate,
@@ -200,19 +201,19 @@ impl HomeDB {
         self.store_encodable("", LATEST_ROOT, &root)
     }
 
-    /// Store block number of an update (by new root)
-    pub fn store_update_block_number(
+    /// Store update metadata (by update's new root)
+    pub fn store_update_metadata(
         &self,
         new_root: H256,
-        block_number: u64,
+        metadata: UpdateMeta,
     ) -> Result<(), DbError> {
-        debug!(new_root = ?new_root, block_number = ?block_number, "storing update block_number in DB");
+        debug!(new_root = ?new_root, metadata = ?metadata, "storing update metadata in DB");
 
-        self.store_keyed_encodable(BLOCK_NUMBER, &new_root, &block_number)
+        self.store_keyed_encodable(BLOCK_NUMBER, &new_root, &metadata)
     }
 
-    /// Retrieve block number of an update (by new root)
-    pub fn retrieve_update_block_number(&self, new_root: H256) -> Result<Option<u64>, DbError> {
+    /// Retrieve update metadata (by update's new root)
+    pub fn retrieve_update_metadata(&self, new_root: H256) -> Result<Option<UpdateMeta>, DbError> {
         self.retrieve_keyed_decodable(BLOCK_NUMBER, &new_root)
     }
 

--- a/rust/optics-core/src/db/home_db.rs
+++ b/rust/optics-core/src/db/home_db.rs
@@ -20,7 +20,7 @@ static PREV_ROOT: &str = "update_prev_root_";
 static PROOF: &str = "proof_";
 static MESSAGE: &str = "message_";
 static UPDATE: &str = "update_";
-static BLOCK_NUMBER: &str = "block_number_";
+static UPDATE_META: &str = "update_metadata_";
 static LATEST_ROOT: &str = "update_latest_root_";
 static LATEST_NONCE: &str = "latest_nonce_";
 static LATEST_LEAF_INDEX: &str = "latest_known_leaf_index_";
@@ -209,12 +209,12 @@ impl HomeDB {
     ) -> Result<(), DbError> {
         debug!(new_root = ?new_root, metadata = ?metadata, "storing update metadata in DB");
 
-        self.store_keyed_encodable(BLOCK_NUMBER, &new_root, &metadata)
+        self.store_keyed_encodable(UPDATE_META, &new_root, &metadata)
     }
 
     /// Retrieve update metadata (by update's new root)
     pub fn retrieve_update_metadata(&self, new_root: H256) -> Result<Option<UpdateMeta>, DbError> {
-        self.retrieve_keyed_decodable(BLOCK_NUMBER, &new_root)
+        self.retrieve_keyed_decodable(UPDATE_META, &new_root)
     }
 
     /// Store a signed update building off latest root

--- a/rust/optics-core/src/db/home_db.rs
+++ b/rust/optics-core/src/db/home_db.rs
@@ -19,6 +19,7 @@ static PREV_ROOT: &str = "update_prev_root_";
 static PROOF: &str = "proof_";
 static MESSAGE: &str = "message_";
 static UPDATE: &str = "update_";
+static BLOCK_NUMBER: &str = "block_number_";
 static LATEST_ROOT: &str = "update_latest_root_";
 static LATEST_NONCE: &str = "latest_nonce_";
 static LATEST_LEAF_INDEX: &str = "latest_known_leaf_index_";
@@ -197,6 +198,22 @@ impl HomeDB {
     fn store_latest_root(&self, root: H256) -> Result<(), DbError> {
         debug!(root = ?root, "storing new latest root in DB");
         self.store_encodable("", LATEST_ROOT, &root)
+    }
+
+    /// Store block number of an update (by new root)
+    pub fn store_update_block_number(
+        &self,
+        new_root: H256,
+        block_number: u64,
+    ) -> Result<(), DbError> {
+        debug!(new_root = ?new_root, block_number = ?block_number, "storing update block_number in DB");
+
+        self.store_keyed_encodable(BLOCK_NUMBER, &new_root, &block_number)
+    }
+
+    /// Retrieve block number of an update (by new root)
+    pub fn retrieve_update_block_number(&self, new_root: H256) -> Result<Option<u64>, DbError> {
+        self.retrieve_keyed_decodable(BLOCK_NUMBER, &new_root)
     }
 
     /// Store a signed update building off latest root

--- a/rust/optics-core/src/types/update.rs
+++ b/rust/optics-core/src/types/update.rs
@@ -94,6 +94,15 @@ impl Update {
     }
 }
 
+/// A Signed Optics Update with Metadata
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SignedUpdateWithMeta {
+    /// Signed update
+    pub signed_update: SignedUpdate,
+    /// Block number
+    pub block_number: u64,
+}
+
 /// A Signed Optics Update
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SignedUpdate {

--- a/rust/optics-core/src/types/update.rs
+++ b/rust/optics-core/src/types/update.rs
@@ -94,13 +94,46 @@ impl Update {
     }
 }
 
+/// Metadata stored about an update
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct UpdateMeta {
+    /// Block number
+    pub block_number: u64,
+}
+
+impl Encode for UpdateMeta {
+    fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
+    where
+        W: std::io::Write,
+    {
+        let mut written = 0;
+        written += self.block_number.write_to(writer)?;
+        Ok(written)
+    }
+}
+
+impl Decode for UpdateMeta {
+    fn read_from<R>(reader: &mut R) -> Result<Self, OpticsError>
+    where
+        R: std::io::Read,
+        Self: Sized,
+    {
+        let mut block_number = [0u8; 8];
+        reader.read_exact(&mut block_number)?;
+
+        Ok(Self {
+            block_number: u64::from_be_bytes(block_number),
+        })
+    }
+}
+
 /// A Signed Optics Update with Metadata
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SignedUpdateWithMeta {
     /// Signed update
     pub signed_update: SignedUpdate,
-    /// Block number
-    pub block_number: u64,
+    /// Metadata
+    pub metadata: UpdateMeta,
 }
 
 /// A Signed Optics Update


### PR DESCRIPTION
- home indexer stores `UpdateMeta` struct in db (keyed by `update.new_root`)
- `UpdateMeta` currently only has `block_number` but we can add any additional fields if needed

Closes #822 