### PR TITLE
fix: indexer retries if rpc misses updates

### DIFF
--- a/rust/optics-core/src/db/mod.rs
+++ b/rust/optics-core/src/db/mod.rs
@@ -1,4 +1,5 @@
 use color_eyre::eyre::WrapErr;
+use ethers::core::types::H256;
 use rocksdb::{DBIterator, Options, DB as Rocks};
 use std::{path::Path, sync::Arc};
 use tracing::info;
@@ -35,6 +36,16 @@ pub enum DbError {
     /// Optics Error
     #[error("{0}")]
     OpticsError(#[from] OpticsError),
+    /// Tried to store leaf not building off latest root
+    #[error("store_latest_update attempted to store leaf not building off latest root. Latest root: {latest_root:?}. Update previous root: {previous_root:?}. Update new root: {new_root:?}.")]
+    NotLatestRoot {
+        /// Actual latest root
+        latest_root: H256,
+        /// Invalid update previous root (should be latest_root)
+        previous_root: H256,
+        /// Invalid update new root
+        new_root: H256,
+    },
 }
 
 type Result<T> = std::result::Result<T, DbError>;

--- a/rust/optics-core/src/db/optics_db.rs
+++ b/rust/optics-core/src/db/optics_db.rs
@@ -291,9 +291,15 @@ impl OpticsDB {
                     self.store_latest_root(&entity, update.update.new_root)?;
                 } else {
                     warn!(
-                        "Attempted to store update not building off latest root: {:?}",
+                        "Attempted to store update not building off latest root: {:?}.",
                         update
-                    )
+                    );
+
+                    return Err(DbError::NotLatestRoot {
+                        latest_root: root,
+                        previous_root: update.update.previous_root,
+                        new_root: update.update.new_root,
+                    });
                 }
             }
             None => self.store_latest_root(&entity, update.update.new_root)?,


### PR DESCRIPTION
- rpc providers occasionally fail to provide all updates within a block range (causes processor to skip updates and get stuck)
- right now, if an update is missing, the indexer will continue on to the next block range (which means that skipped update will never be found after that)
- fix: attempted store of update that doesn't build off of last seen root causes (i.e. missing update) causes the indexer to retry indexing for the same block range until it finds the missing update