### PR TITLE
fix: ContractSync retries block ranges if updates/messages are missing

### DIFF
--- a/rust/optics-base/src/contract_sync.rs
+++ b/rust/optics-base/src/contract_sync.rs
@@ -1,7 +1,12 @@
+use color_eyre::Result;
 use optics_core::db::OpticsDB;
-use optics_core::{CommittedMessage, CommonIndexer, HomeIndexer};
+use optics_core::{
+    CommittedMessage, Indexer, LatestMessage, LatestUpdate, RawCommittedMessage,
+    SignedUpdateWithMeta,
+};
 
-use tokio::time::sleep;
+use futures_util::future::select_all;
+use tokio::{task::JoinHandle, time::sleep};
 use tracing::{info, info_span};
 use tracing::{instrument::Instrumented, Instrument};
 
@@ -12,6 +17,9 @@ use std::time::Duration;
 
 static UPDATES_LAST_INSPECTED: &str = "updates_last_inspected";
 static MESSAGES_LAST_INSPECTED: &str = "messages_last_inspected";
+
+static LAST_UPDATE: &str = "last_update";
+static LAST_MESSAGE: &str = "last_message";
 
 /// Entity that drives the syncing of an agent's db with on-chain data.
 /// Extracts chain-specific data (emitted updates, messages, etc) from an
@@ -26,6 +34,8 @@ pub struct ContractSync<I> {
     from_height: u32,
     chunk_size: u32,
     indexed_height: prometheus::IntGauge,
+    last_update: Option<LatestUpdate>,
+    last_message: Option<LatestMessage>,
 }
 
 impl<I> ContractSync<I>
@@ -48,7 +58,59 @@ where
             from_height,
             chunk_size,
             indexed_height,
+            last_update: None,
+            last_message: None,
         }
+    }
+
+    fn updates_valid(
+        _last_update: &Option<LatestUpdate>,
+        _sorted_updates: &[SignedUpdateWithMeta],
+    ) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn messages_valid(
+        _last_message: &Option<LatestMessage>,
+        _sorted_messages: &[RawCommittedMessage],
+    ) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn store_updates(db: OpticsDB, sorted_updates: &[SignedUpdateWithMeta]) -> Result<()> {
+        for update_with_meta in sorted_updates {
+            db.store_latest_update(&update_with_meta.signed_update)?;
+            db.store_update_metadata(
+                update_with_meta.signed_update.update.new_root,
+                update_with_meta.metadata,
+            )?;
+
+            info!(
+                "Stored new update in db. Block number: {}. Previous root: {}. New root: {}.",
+                &update_with_meta.metadata.block_number,
+                &update_with_meta.signed_update.update.previous_root,
+                &update_with_meta.signed_update.update.new_root,
+            );
+        }
+
+        Ok(())
+    }
+
+    fn store_messages(db: OpticsDB, messages: &[RawCommittedMessage]) -> Result<()> {
+        for message in messages {
+            db.store_raw_committed_message(message)?;
+
+            let committed_message: CommittedMessage = message.clone().try_into()?;
+            info!(
+                "Stored new message in db. Leaf index: {}. Origin: {}. Destination: {}. Nonce: {}.",
+                &committed_message.leaf_index,
+                &committed_message.message.origin,
+                &committed_message.message.destination,
+                &committed_message.message.nonce
+            );
+        }
+
+        Ok(())
     }
 
     /// Spawn task that continuously looks for new on-chain updates and stores
@@ -68,9 +130,13 @@ where
                 .retrieve_decodable("", UPDATES_LAST_INSPECTED)
                 .expect("db failure")
                 .unwrap_or(from_height);
+
+            let mut last_update: Option<LatestUpdate> =
+                db.retrieve_decodable("", LAST_UPDATE).expect("db failure");
+
             info!(
                 next_height = next_height,
-                "resuming indexer from {}", next_height
+                "resuming update indexer from {}", next_height
             );
 
             loop {
@@ -87,26 +153,30 @@ where
                     to
                 );
 
-                let sorted_updates = indexer.fetch_sorted_updates(next_height, to).await?;
+                let sorted_updates = indexer.fetch_updates(next_height, to).await?;
 
-                for update_with_meta in sorted_updates {
-                    db
-                        .store_latest_update(&update_with_meta.signed_update)?;
-                    db.store_update_metadata(
-                        update_with_meta.signed_update.update.new_root,
-                        update_with_meta.metadata,
-                    )?;
+                if !sorted_updates.is_empty() {
+                    // If update chain missing update(s), restart indexing at
+                    // last height of last seen update
+                    if !Self::updates_valid(&last_update, &sorted_updates)? {
+                        next_height = match &last_update {
+                            Some(last) => last.block_range_start,
+                            None => from_height,
+                        };
+                        continue;
+                    }
 
-                    info!(
-                        "Stored new update in db. Block number: {}. Previous root: {}. New root: {}.",
-                        &update_with_meta.metadata.block_number,
-                        &update_with_meta.signed_update.update.previous_root,
-                        &update_with_meta.signed_update.update.new_root,
-                    );
+                    Self::store_updates(db.clone(), &sorted_updates)?;
+
+                    last_update = Some(LatestUpdate {
+                        update: sorted_updates.last().unwrap().signed_update.update,
+                        block_range_start: next_height,
+                    });
+                    db.store_encodable("", LAST_UPDATE, last_update.as_ref().unwrap())?;
                 }
 
-                db
-                    .store_encodable("", UPDATES_LAST_INSPECTED, &next_height)?;
+                db.store_encodable("", UPDATES_LAST_INSPECTED, &next_height)?;
+
                 next_height = to;
                 // sleep here if we've caught up
                 if to == tip {
@@ -139,9 +209,13 @@ where
                 .retrieve_decodable("", MESSAGES_LAST_INSPECTED)
                 .expect("db failure")
                 .unwrap_or(from_height);
+
+            let mut last_message: Option<LatestMessage> =
+                db.retrieve_decodable("", LAST_MESSAGE).expect("db failure");
+
             info!(
                 next_height = next_height,
-                "resuming indexer from {}", next_height
+                "resuming message indexer from {}", next_height
             );
 
             loop {
@@ -158,29 +232,54 @@ where
                     to
                 );
 
-                let messages = indexer.fetch_sorted_messages(next_height, to).await?;
+                let sorted_messages = indexer.fetch_messages(next_height, to).await?;
 
-                for message in messages {
-                    db.store_raw_committed_message(&message)?;
+                if !sorted_messages.is_empty() {
+                    // If message chain missing message(s), restart indexing at
+                    // last height of last seen message
+                    if !Self::messages_valid(&last_message, &sorted_messages)? {
+                        next_height = match &last_message {
+                            Some(last) => last.block_range_start,
+                            None => from_height,
+                        };
+                        continue;
+                    }
 
-                    let committed_message: CommittedMessage = message.try_into()?;
-                    info!(
-                        "Stored new message in db. Leaf index: {}. Origin: {}. Destination: {}. Nonce: {}.",
-                        &committed_message.leaf_index,
-                        &committed_message.message.origin,
-                        &committed_message.message.destination,
-                        &committed_message.message.nonce
-                    );
+                    Self::store_messages(db.clone(), &sorted_messages)?;
+
+                    last_message = Some(LatestMessage {
+                        leaf_index: sorted_messages.last().unwrap().leaf_index,
+                        block_range_start: next_height,
+                    });
+                    db.store_encodable("", LAST_MESSAGE, last_message.as_ref().unwrap())?;
                 }
 
-                db
-                    .store_encodable("", MESSAGES_LAST_INSPECTED, &next_height)?;
+                db.store_encodable("", MESSAGES_LAST_INSPECTED, &next_height)?;
+
                 next_height = to;
                 // sleep here if we've caught up
                 if to == tip {
                     sleep(Duration::from_secs(100)).await;
                 }
             }
+        })
+        .in_current_span()
+    }
+
+    /// Spawn task that continuously indexes the contract's chain and stores
+    /// messages and updates in the agent's db
+    pub fn spawn(self) -> Instrumented<JoinHandle<Result<()>>> {
+        let span = info_span!("ContractSync");
+
+        tokio::spawn(async move {
+            let sync_tasks = vec![self.index_updates(), self.index_messages()];
+
+            let (_, _, remaining) = select_all(sync_tasks).await;
+            for task in remaining.into_iter() {
+                cancel_task!(task);
+            }
+
+            Ok(())
         })
         .instrument(span)
     }

--- a/rust/optics-core/src/types/messages.rs
+++ b/rust/optics-core/src/types/messages.rs
@@ -102,3 +102,39 @@ impl std::fmt::Display for OpticsMessage {
         )
     }
 }
+
+/// Latest update stored by an contract sync
+#[derive(Debug)]
+pub struct LatestMessage {
+    /// Leaf index of last seen message
+    pub leaf_index: u32,
+    /// Block range start of last seen message
+    pub block_range_start: u32,
+}
+
+impl Encode for LatestMessage {
+    fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
+    where
+        W: std::io::Write,
+    {
+        let mut written = 0;
+        written += self.leaf_index.write_to(writer)?;
+        written += self.block_range_start.write_to(writer)?;
+        Ok(written)
+    }
+}
+
+impl Decode for LatestMessage {
+    fn read_from<R>(reader: &mut R) -> Result<Self, OpticsError>
+    where
+        R: std::io::Read,
+        Self: Sized,
+    {
+        let leaf_index = u32::read_from(reader)?;
+        let block_range_start = u32::read_from(reader)?;
+        Ok(Self {
+            leaf_index,
+            block_range_start,
+        })
+    }
+}

--- a/rust/optics-core/src/types/update.rs
+++ b/rust/optics-core/src/types/update.rs
@@ -98,7 +98,7 @@ impl Update {
 #[derive(Debug)]
 pub struct LatestUpdate {
     /// Last seen update
-    pub update: Update,
+    pub new_root: H256,
     /// Block range start of last seen message
     pub block_range_start: u32,
 }
@@ -109,7 +109,7 @@ impl Encode for LatestUpdate {
         W: std::io::Write,
     {
         let mut written = 0;
-        written += self.update.write_to(writer)?;
+        written += self.new_root.write_to(writer)?;
         written += self.block_range_start.write_to(writer)?;
         Ok(written)
     }
@@ -121,10 +121,10 @@ impl Decode for LatestUpdate {
         R: std::io::Read,
         Self: Sized,
     {
-        let update = Update::read_from(reader)?;
+        let new_root = H256::read_from(reader)?;
         let block_range_start = u32::read_from(reader)?;
         Ok(Self {
-            update,
+            new_root,
             block_range_start,
         })
     }

--- a/rust/optics-core/src/types/update.rs
+++ b/rust/optics-core/src/types/update.rs
@@ -94,6 +94,42 @@ impl Update {
     }
 }
 
+/// Latest update stored by an contract sync
+#[derive(Debug)]
+pub struct LatestUpdate {
+    /// Last seen update
+    pub update: Update,
+    /// Block range start of last seen message
+    pub block_range_start: u32,
+}
+
+impl Encode for LatestUpdate {
+    fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
+    where
+        W: std::io::Write,
+    {
+        let mut written = 0;
+        written += self.update.write_to(writer)?;
+        written += self.block_range_start.write_to(writer)?;
+        Ok(written)
+    }
+}
+
+impl Decode for LatestUpdate {
+    fn read_from<R>(reader: &mut R) -> Result<Self, OpticsError>
+    where
+        R: std::io::Read,
+        Self: Sized,
+    {
+        let update = Update::read_from(reader)?;
+        let block_range_start = u32::read_from(reader)?;
+        Ok(Self {
+            update,
+            block_range_start,
+        })
+    }
+}
+
 /// Metadata stored about an update
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct UpdateMeta {


### PR DESCRIPTION
Builds on #925

Closes #927