### PR TITLE
Switch packages to use the correct npm org

### DIFF
--- a/solidity/optics-core/package-lock.json
+++ b/solidity/optics-core/package-lock.json
@@ -1,16 +1,16 @@
 {
-  "name": "@celo-org/optics-sol",
+  "name": "@celo/optics-sol",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@celo-org/optics-sol",
+      "name": "@celo/optics-sol",
       "version": "0.0.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts": "^3.4.2",
-        "@openzeppelin/contracts-upgradeable": "^3.4.2",
+        "@openzeppelin/contracts-upgradeable": "~3.4.2",
         "@summa-tx/memview-sol": "^2.0.0",
         "dotenv": "^10.0.0",
         "ts-generator": "^0.1.1"

--- a/solidity/optics-core/package.json
+++ b/solidity/optics-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@celo-org/optics-sol",
+  "name": "@celo/optics-sol",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-etherscan": "^2.1.2",

--- a/solidity/optics-xapps/contracts/Router.sol
+++ b/solidity/optics-xapps/contracts/Router.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.6.11;
 // ============ Internal Imports ============
 import {XAppConnectionClient} from "./XAppConnectionClient.sol";
 // ============ External Imports ============
-import {IMessageRecipient} from "@celo-org/optics-sol/interfaces/IMessageRecipient.sol";
+import {IMessageRecipient} from "@celo/optics-sol/interfaces/IMessageRecipient.sol";
 
 abstract contract Router is XAppConnectionClient, IMessageRecipient {
     // ============ Mutable Storage ============

--- a/solidity/optics-xapps/contracts/XAppConnectionClient.sol
+++ b/solidity/optics-xapps/contracts/XAppConnectionClient.sol
@@ -2,8 +2,8 @@
 pragma solidity >=0.6.11;
 
 // ============ External Imports ============
-import {Home} from "@celo-org/optics-sol/contracts/Home.sol";
-import {XAppConnectionManager} from "@celo-org/optics-sol/contracts/XAppConnectionManager.sol";
+import {Home} from "@celo/optics-sol/contracts/Home.sol";
+import {XAppConnectionManager} from "@celo/optics-sol/contracts/XAppConnectionManager.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 abstract contract XAppConnectionClient is OwnableUpgradeable {

--- a/solidity/optics-xapps/contracts/bridge/BridgeRouter.sol
+++ b/solidity/optics-xapps/contracts/bridge/BridgeRouter.sol
@@ -8,9 +8,9 @@ import {XAppConnectionClient} from "../XAppConnectionClient.sol";
 import {IBridgeToken} from "../../interfaces/bridge/IBridgeToken.sol";
 import {BridgeMessage} from "./BridgeMessage.sol";
 // ============ External Imports ============
-import {Home} from "@celo-org/optics-sol/contracts/Home.sol";
-import {Version0} from "@celo-org/optics-sol/contracts/Version0.sol";
-import {TypeCasts} from "@celo-org/optics-sol/contracts/XAppConnectionManager.sol";
+import {Home} from "@celo/optics-sol/contracts/Home.sol";
+import {Version0} from "@celo/optics-sol/contracts/Version0.sol";
+import {TypeCasts} from "@celo/optics-sol/contracts/XAppConnectionManager.sol";
 import {TypedMemView} from "@summa-tx/memview-sol/contracts/TypedMemView.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";

--- a/solidity/optics-xapps/contracts/bridge/BridgeToken.sol
+++ b/solidity/optics-xapps/contracts/bridge/BridgeToken.sol
@@ -5,8 +5,8 @@ pragma solidity >=0.6.11;
 import {IBridgeToken} from "../../interfaces/bridge/IBridgeToken.sol";
 import {ERC20} from "./vendored/OZERC20.sol";
 // ============ External Imports ============
-import {Version0} from "@celo-org/optics-sol/contracts/Version0.sol";
-import {TypeCasts} from "@celo-org/optics-sol/contracts/XAppConnectionManager.sol";
+import {Version0} from "@celo/optics-sol/contracts/Version0.sol";
+import {TypeCasts} from "@celo/optics-sol/contracts/XAppConnectionManager.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 contract BridgeToken is Version0, IBridgeToken, OwnableUpgradeable, ERC20 {

--- a/solidity/optics-xapps/contracts/bridge/ETHHelper.sol
+++ b/solidity/optics-xapps/contracts/bridge/ETHHelper.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.6.11;
 import {BridgeRouter} from "./BridgeRouter.sol";
 import {IWeth} from "../../interfaces/bridge/IWeth.sol";
 // ============ External Imports ============
-import {TypeCasts} from "@celo-org/optics-sol/contracts/XAppConnectionManager.sol";
+import {TypeCasts} from "@celo/optics-sol/contracts/XAppConnectionManager.sol";
 
 contract ETHHelper {
     // ============ Immutables ============

--- a/solidity/optics-xapps/contracts/bridge/TokenRegistry.sol
+++ b/solidity/optics-xapps/contracts/bridge/TokenRegistry.sol
@@ -7,8 +7,8 @@ import {Encoding} from "./Encoding.sol";
 import {IBridgeToken} from "../../interfaces/bridge/IBridgeToken.sol";
 import {XAppConnectionClient} from "../XAppConnectionClient.sol";
 // ============ External Imports ============
-import {TypeCasts} from "@celo-org/optics-sol/contracts/XAppConnectionManager.sol";
-import {UpgradeBeaconProxy} from "@celo-org/optics-sol/contracts/upgrade/UpgradeBeaconProxy.sol";
+import {TypeCasts} from "@celo/optics-sol/contracts/XAppConnectionManager.sol";
+import {UpgradeBeaconProxy} from "@celo/optics-sol/contracts/upgrade/UpgradeBeaconProxy.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {TypedMemView} from "@summa-tx/memview-sol/contracts/TypedMemView.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";

--- a/solidity/optics-xapps/contracts/bridge/test/MockCore.sol
+++ b/solidity/optics-xapps/contracts/bridge/test/MockCore.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.11;
 
-import {MerkleTreeManager} from "@celo-org/optics-sol/contracts/Merkle.sol";
-import {QueueManager} from "@celo-org/optics-sol/contracts/Queue.sol";
+import {MerkleTreeManager} from "@celo/optics-sol/contracts/Merkle.sol";
+import {QueueManager} from "@celo/optics-sol/contracts/Queue.sol";
 
-import {Message} from "@celo-org/optics-sol/libs/Message.sol";
-import {MerkleLib} from "@celo-org/optics-sol/libs/Merkle.sol";
-import {QueueLib} from "@celo-org/optics-sol/libs/Queue.sol";
+import {Message} from "@celo/optics-sol/libs/Message.sol";
+import {MerkleLib} from "@celo/optics-sol/libs/Merkle.sol";
+import {QueueLib} from "@celo/optics-sol/libs/Queue.sol";
 
 // We reproduce a significant amount of logic from `Home` to ensure that
 // calling dispatch here is AT LEAST AS EXPENSIVE as calling it on home

--- a/solidity/optics-xapps/package-lock.json
+++ b/solidity/optics-xapps/package-lock.json
@@ -1,17 +1,17 @@
 {
-  "name": "@celo-org/optics-xapps-sol",
+  "name": "@celo/optics-xapps-sol",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@celo-org/optics-xapps-sol",
+      "name": "@celo/optics-xapps-sol",
       "version": "0.0.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@celo-org/optics-sol": "file:../optics-core",
-        "@openzeppelin/contracts": "^3.4.2",
-        "@openzeppelin/contracts-upgradeable": "^3.4.2",
+        "@celo/optics-sol": "file:../optics-core",
+        "@openzeppelin/contracts": "~3.4.2",
+        "@openzeppelin/contracts-upgradeable": "~3.4.2",
         "@summa-tx/memview-sol": "^2.0.0"
       },
       "devDependencies": {
@@ -38,12 +38,12 @@
       }
     },
     "../optics-core": {
-      "name": "@celo-org/optics-sol",
+      "name": "@celo/optics-sol",
       "version": "0.0.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@openzeppelin/contracts": "^3.4.0",
-        "@openzeppelin/contracts-upgradeable": "~3.4.0",
+        "@openzeppelin/contracts": "^3.4.2",
+        "@openzeppelin/contracts-upgradeable": "~3.4.2",
         "@summa-tx/memview-sol": "^2.0.0",
         "dotenv": "^10.0.0",
         "ts-generator": "^0.1.1"
@@ -172,7 +172,7 @@
         "node": ">=4"
       }
     },
-    "node_modules/@celo-org/optics-sol": {
+    "node_modules/@celo/optics-sol": {
       "resolved": "../optics-core",
       "link": true
     },
@@ -23728,14 +23728,14 @@
         }
       }
     },
-    "@celo-org/optics-sol": {
+    "@celo/optics-sol": {
       "version": "file:../optics-core",
       "requires": {
         "@nomiclabs/hardhat-ethers": "^2.0.1",
         "@nomiclabs/hardhat-etherscan": "^2.1.2",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
-        "@openzeppelin/contracts": "^3.4.0",
-        "@openzeppelin/contracts-upgradeable": "~3.4.0",
+        "@openzeppelin/contracts": "^3.4.2",
+        "@openzeppelin/contracts-upgradeable": "~3.4.2",
         "@summa-tx/memview-sol": "^2.0.0",
         "@typechain/ethers-v5": "^7.0.0",
         "@typechain/hardhat": "^2.0.1",

--- a/solidity/optics-xapps/package.json
+++ b/solidity/optics-xapps/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@celo-org/optics-xapps-sol",
+  "name": "@celo/optics-xapps-sol",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-etherscan": "^2.1.2",
@@ -42,7 +42,7 @@
   "author": "James Prestwich",
   "license": "MIT OR Apache-2.0",
   "dependencies": {
-    "@celo-org/optics-sol": "file:../optics-core",
+    "@celo/optics-sol": "file:../optics-core",
     "@openzeppelin/contracts": "~3.4.2",
     "@openzeppelin/contracts-upgradeable": "~3.4.2",
     "@summa-tx/memview-sol": "^2.0.0"


### PR DESCRIPTION
Even those these packages aren't published we're switching them to use the correct npm organization in case someone were to actually publish something malicious to the npm registry using these names.